### PR TITLE
Update CMSIS-DAP to 2.0

### DIFF
--- a/src/DAP/CMSIS_DAP.c
+++ b/src/DAP/CMSIS_DAP.c
@@ -1,45 +1,51 @@
 /* CMSIS-DAP Interface Firmware
- * Copyright (c) 2009-2013 ARM Limited
+ * Copyright (c) 2013-2017 ARM Limited. All rights reserved.
  * Copyright (c) 2015 Devan Lai - modifications for use within the
  *                                dap42 project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        1. December 2017
+ * $Revision:    V2.0.0
+ *
+ * Project:      CMSIS-DAP Source
+ * Title:        DAP.c CMSIS-DAP Commands
+ *
+ *---------------------------------------------------------------------------*/
 
 #include <string.h>
 #include "DAP/CMSIS_DAP_hal.h"
 #include "DAP/CMSIS_DAP.h"
 
-#include <libopencm3/cm3/systick.h>
-#include <libopencmsis/core_cm3.h>
-
 #ifndef __weak
 #define __weak __attribute__ ((weak))
 #endif
 
-#define DAP_FW_VER      "1.0"   // Firmware Version
-
 #if (DAP_PACKET_SIZE < 64U)
-#error "Minimum Packet Size is 64"
+#error "Minimum Packet Size is 64!"
 #endif
 #if (DAP_PACKET_SIZE > 32768U)
-#error "Maximum Packet Size is 32768"
+#error "Maximum Packet Size is 32768!"
 #endif
 #if (DAP_PACKET_COUNT < 1U)
-#error "Minimum Packet Count is 1"
+#error "Minimum Packet Count is 1!"
 #endif
 #if (DAP_PACKET_COUNT > 255U)
-#error "Maximum Packet Count is 255"
+#error "Maximum Packet Count is 255!"
 #endif
 
 
@@ -56,20 +62,11 @@
 volatile uint8_t    DAP_TransferAbort;  // Transfer Abort Flag
 
 
-#ifdef DAP_VENDOR
-const char DAP_Vendor [] = DAP_VENDOR;
-#endif
-#ifdef DAP_PRODUCT
-const char DAP_Product[] = DAP_PRODUCT;
-#endif
-#ifdef DAP_SER_NUM
-const char DAP_SerNum [] = DAP_SER_NUM;
-#endif
-const char DAP_FW_Ver [] = DAP_FW_VER;
+static const char DAP_FW_Ver [] = DAP_FW_VER;
 
 #if TARGET_DEVICE_FIXED
-const char TargetDeviceVendor [] = TARGET_DEVICE_VENDOR;
-const char TargetDeviceName   [] = TARGET_DEVICE_NAME;
+static const char TargetDeviceVendor [] = TARGET_DEVICE_VENDOR;
+static const char TargetDeviceName   [] = TARGET_DEVICE_NAME;
 #endif
 
 
@@ -82,43 +79,57 @@ static uint8_t DAP_Info(uint8_t id, uint8_t *info) {
 
   switch (id) {
     case DAP_ID_VENDOR:
-#ifdef DAP_VENDOR
-      memcpy(info, DAP_Vendor, sizeof(DAP_Vendor));
-      length = (uint8_t)sizeof(DAP_Vendor);
-#endif
+      length = DAP_GetVendorString((char *)info);
       break;
     case DAP_ID_PRODUCT:
-#ifdef DAP_PRODUCT
-      memcpy(info, DAP_Product, sizeof(DAP_Product));
-      length = (uint8_t)sizeof(DAP_Product);
-#endif
+      length = DAP_GetProductString((char *)info);
       break;
     case DAP_ID_SER_NUM:
-#ifdef DAP_SER_NUM
-      memcpy(info, DAP_SerNum, sizeof(DAP_SerNum));
-      length = (uint8_t)sizeof(DAP_SerNum);
-#endif
+      length = DAP_GetSerNumString((char *)info);
       break;
     case DAP_ID_FW_VER:
-      memcpy(info, DAP_FW_Ver, sizeof(DAP_FW_Ver));
       length = (uint8_t)sizeof(DAP_FW_Ver);
+      memcpy(info, DAP_FW_Ver, length);
       break;
     case DAP_ID_DEVICE_VENDOR:
 #if TARGET_DEVICE_FIXED
-      memcpy(info, TargetDeviceVendor, sizeof(TargetDeviceVendor));
       length = (uint8_t)sizeof(TargetDeviceVendor);
+      memcpy(info, TargetDeviceVendor, length);
 #endif
       break;
     case DAP_ID_DEVICE_NAME:
 #if TARGET_DEVICE_FIXED
-      memcpy(info, TargetDeviceName, sizeof(TargetDeviceName));
       length = (uint8_t)sizeof(TargetDeviceName);
+      memcpy(info, TargetDeviceName, length);
 #endif
       break;
     case DAP_ID_CAPABILITIES:
-      info[0] = ((DAP_SWD  != 0) ? (1U << 0) : 0U) |
-                ((DAP_JTAG != 0) ? (1U << 1) : 0U);
+      info[0] = ((DAP_SWD  != 0)         ? (1U << 0) : 0U) |
+                ((DAP_JTAG != 0)         ? (1U << 1) : 0U) |
+                ((SWO_UART != 0)         ? (1U << 2) : 0U) |
+                ((SWO_MANCHESTER != 0)   ? (1U << 3) : 0U) |
+                /* Atomic Commands  */     (1U << 4)       |
+                ((TIMESTAMP_CLOCK != 0U) ? (1U << 5) : 0U) |
+                ((SWO_STREAM != 0U)      ? (1U << 6) : 0U);
       length = 1U;
+      break;
+    case DAP_ID_TIMESTAMP_CLOCK:
+#if (TIMESTAMP_CLOCK != 0U)
+      info[0] = (uint8_t)(TIMESTAMP_CLOCK >>  0);
+      info[1] = (uint8_t)(TIMESTAMP_CLOCK >>  8);
+      info[2] = (uint8_t)(TIMESTAMP_CLOCK >> 16);
+      info[3] = (uint8_t)(TIMESTAMP_CLOCK >> 24);
+      length = 4U;
+#endif
+      break;
+    case DAP_ID_SWO_BUFFER_SIZE:
+#if ((SWO_UART != 0) || (SWO_MANCHESTER != 0))
+      info[0] = (uint8_t)(SWO_BUFFER_SIZE >>  0);
+      info[1] = (uint8_t)(SWO_BUFFER_SIZE >>  8);
+      info[2] = (uint8_t)(SWO_BUFFER_SIZE >> 16);
+      info[3] = (uint8_t)(SWO_BUFFER_SIZE >> 24);
+      length = 4U;
+#endif
       break;
     case DAP_ID_PACKET_SIZE:
       info[0] = (uint8_t)(DAP_PACKET_SIZE >> 0);
@@ -129,34 +140,12 @@ static uint8_t DAP_Info(uint8_t id, uint8_t *info) {
       info[0] = DAP_PACKET_COUNT;
       length = 1U;
       break;
+    default:
+      break;
   }
 
   return (length);
 }
-
-
-// Timer Functions
-
-#if ((DAP_SWD != 0) || (DAP_JTAG != 0))
-
-// Start Timer
-static __inline void TIMER_START (uint32_t usec) {
-  STK_CVR  = 0;
-  STK_RVR = usec * CPU_CLOCK/1000000;
-  STK_CSR = STK_CSR_ENABLE | STK_CSR_CLKSOURCE;
-}
-
-// Stop Timer
-static __inline void TIMER_STOP (void) {
-  STK_CSR = 0;
-}
-
-// Check if Timer expired
-static __inline uint32_t TIMER_EXPIRED (void) {
-  return ((STK_CSR & STK_CSR_COUNTFLAG) ? 1 : 0);
-}
-
-#endif
 
 
 // Delay for specified time
@@ -170,24 +159,27 @@ void Delayms(uint32_t delay) {
 // Process Delay command and prepare response
 //   request:  pointer to request data
 //   response: pointer to response data
-//   return:   number of bytes in response
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
 static uint32_t DAP_Delay(const uint8_t *request, uint8_t *response) {
   uint32_t delay;
 
-  delay  = *(request+0) | (*(request+1) << 8);
+  delay  = (uint32_t)(*(request+0)) |
+           (uint32_t)(*(request+1) << 8);
   delay *= ((CPU_CLOCK/1000000U) + (DELAY_SLOW_CYCLES-1U)) / DELAY_SLOW_CYCLES;
 
   PIN_DELAY_SLOW(delay);
 
   *response = DAP_OK;
-  return (1U);
+  return ((2U << 16) | 1U);
 }
 
 
 // Process Host Status command and prepare response
 //   request:  pointer to request data
 //   response: pointer to response data
-//   return:   number of bytes in response
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
 static uint32_t DAP_HostStatus(const uint8_t *request, uint8_t *response) {
 
   switch (*request) {
@@ -199,18 +191,19 @@ static uint32_t DAP_HostStatus(const uint8_t *request, uint8_t *response) {
       break;
     default:
       *response = DAP_ERROR;
-      return (1U);
+      return ((2U << 16) | 1U);
   }
 
   *response = DAP_OK;
-  return (1U);
+  return ((2U << 16) | 1U);
 }
 
 
 // Process Connect command and prepare response
 //   request:  pointer to request data
 //   response: pointer to response data
-//   return:   number of bytes in response
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
 static uint32_t DAP_Connect(const uint8_t *request, uint8_t *response) {
   uint32_t port;
 
@@ -234,17 +227,16 @@ static uint32_t DAP_Connect(const uint8_t *request, uint8_t *response) {
       break;
 #endif
     default:
-      *response = DAP_PORT_DISABLED;
-      return (1U);
+      port = DAP_PORT_DISABLED;
+      break;
   }
 
-  *response = port;
-  return (1U);
+  *response = (uint8_t)port;
+  return ((1U << 16) | 1U);
 }
 
 
 // Process Disconnect command and prepare response
-//   request:  pointer to request data
 //   response: pointer to response data
 //   return:   number of bytes in response
 static uint32_t DAP_Disconnect(uint8_t *response) {
@@ -258,7 +250,6 @@ static uint32_t DAP_Disconnect(uint8_t *response) {
 
 
 // Process Reset Target command and prepare response
-//   request:  pointer to request data
 //   response: pointer to response data
 //   return:   number of bytes in response
 static uint32_t DAP_ResetTarget(uint8_t *response) {
@@ -272,66 +263,88 @@ static uint32_t DAP_ResetTarget(uint8_t *response) {
 // Process SWJ Pins command and prepare response
 //   request:  pointer to request data
 //   response: pointer to response data
-//   return:   number of bytes in response
-#if ((DAP_SWD != 0) || (DAP_JTAG != 0))
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
 static uint32_t DAP_SWJ_Pins(const uint8_t *request, uint8_t *response) {
+#if ((DAP_SWD != 0) || (DAP_JTAG != 0))
   uint32_t value;
   uint32_t select;
   uint32_t wait;
+  uint32_t timestamp;
 
-  value  =  *(request+0);
-  select =  *(request+1);
-  wait   = (*(request+2) <<  0) |
-           (*(request+3) <<  8) |
-           (*(request+4) << 16) |
-           (*(request+5) << 24);
+  value  = (uint32_t) *(request+0);
+  select = (uint32_t) *(request+1);
+  wait   = (uint32_t)(*(request+2) <<  0) |
+           (uint32_t)(*(request+3) <<  8) |
+           (uint32_t)(*(request+4) << 16) |
+           (uint32_t)(*(request+5) << 24);
 
-  if (select & (1U << DAP_SWJ_SWCLK_TCK)) {
-    if (value & (1U << DAP_SWJ_SWCLK_TCK)) {
+  if ((select & (1U << DAP_SWJ_SWCLK_TCK)) != 0U) {
+    if ((value & (1U << DAP_SWJ_SWCLK_TCK)) != 0U) {
       PIN_SWCLK_TCK_SET();
     } else {
       PIN_SWCLK_TCK_CLR();
     }
   }
-  if (select & (1U << DAP_SWJ_SWDIO_TMS)) {
-    if (value & (1U << DAP_SWJ_SWDIO_TMS)) {
+  if ((select & (1U << DAP_SWJ_SWDIO_TMS)) != 0U) {
+    if ((value & (1U << DAP_SWJ_SWDIO_TMS)) != 0U) {
       PIN_SWDIO_TMS_SET();
     } else {
       PIN_SWDIO_TMS_CLR();
     }
   }
-  if (select & (1U << DAP_SWJ_TDI)) {
+  if ((select & (1U << DAP_SWJ_TDI)) != 0U) {
     PIN_TDI_OUT(value >> DAP_SWJ_TDI);
   }
-  if (select & (1U << DAP_SWJ_nTRST)) {
+  if ((select & (1U << DAP_SWJ_nTRST)) != 0U) {
     PIN_nTRST_OUT(value >> DAP_SWJ_nTRST);
   }
-  if (select & (1U << DAP_SWJ_nRESET)) {
+  if ((select & (1U << DAP_SWJ_nRESET)) != 0U){
     PIN_nRESET_OUT(value >> DAP_SWJ_nRESET);
   }
 
-  if (wait) {
-    if (wait > 3000000U) { wait = 3000000U; }
-    TIMER_START(wait);
+  if (wait != 0U) {
+#if (TIMESTAMP_CLOCK != 0U)
+    if (wait > 3000000U) {
+      wait = 3000000U;
+    }
+#if (TIMESTAMP_CLOCK >= 1000000U)
+    wait *= TIMESTAMP_CLOCK / 1000000U;
+#else
+    wait /= 1000000U / TIMESTAMP_CLOCK;
+#endif
+#else
+    wait  = 1U;
+#endif
+    timestamp = TIMESTAMP_GET();
     do {
-      if (select & (1U << DAP_SWJ_SWCLK_TCK)) {
-        if ((value >> DAP_SWJ_SWCLK_TCK) ^ PIN_SWCLK_TCK_IN()) { continue; }
+      if ((select & (1U << DAP_SWJ_SWCLK_TCK)) != 0U) {
+        if ((value >> DAP_SWJ_SWCLK_TCK) ^ PIN_SWCLK_TCK_IN()) {
+          continue;
+        }
       }
-      if (select & (1U << DAP_SWJ_SWDIO_TMS)) {
-        if ((value >> DAP_SWJ_SWDIO_TMS) ^ PIN_SWDIO_TMS_IN()) { continue; }
+      if ((select & (1U << DAP_SWJ_SWDIO_TMS)) != 0U) {
+        if ((value >> DAP_SWJ_SWDIO_TMS) ^ PIN_SWDIO_TMS_IN()) {
+          continue;
+        }
       }
-      if (select & (1U << DAP_SWJ_TDI)) {
-        if ((value >> DAP_SWJ_TDI) ^ PIN_TDI_IN()) { continue; }
+      if ((select & (1U << DAP_SWJ_TDI)) != 0U) {
+        if ((value >> DAP_SWJ_TDI) ^ PIN_TDI_IN()) {
+          continue;
+        }
       }
-      if (select & (1U << DAP_SWJ_nTRST)) {
-        if ((value >> DAP_SWJ_nTRST) ^ PIN_nTRST_IN()) { continue; }
+      if ((select & (1U << DAP_SWJ_nTRST)) != 0U) {
+        if ((value >> DAP_SWJ_nTRST) ^ PIN_nTRST_IN()) {
+          continue;
+        }
       }
-      if (select & (1U << DAP_SWJ_nRESET)) {
-        if ((value >> DAP_SWJ_nRESET) ^ PIN_nRESET_IN()) { continue; }
+      if ((select & (1U << DAP_SWJ_nRESET)) != 0U) {
+        if ((value >> DAP_SWJ_nRESET) ^ PIN_nRESET_IN()) {
+          continue;
+        }
       }
       break;
-    } while (!TIMER_EXPIRED());
-    TIMER_STOP();
+    } while ((TIMESTAMP_GET() - timestamp) < wait);
   }
 
   value = (PIN_SWCLK_TCK_IN() << DAP_SWJ_SWCLK_TCK) |
@@ -342,28 +355,32 @@ static uint32_t DAP_SWJ_Pins(const uint8_t *request, uint8_t *response) {
           (PIN_nRESET_IN()    << DAP_SWJ_nRESET);
 
   *response = (uint8_t)value;
-  return (1U);
-}
+#else
+  *response = 0U;
 #endif
+
+  return ((6U << 16) | 1U);
+}
 
 
 // Process SWJ Clock command and prepare response
 //   request:  pointer to request data
 //   response: pointer to response data
-//   return:   number of bytes in response
-#if ((DAP_SWD != 0) || (DAP_JTAG != 0))
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
 static uint32_t DAP_SWJ_Clock(const uint8_t *request, uint8_t *response) {
+#if ((DAP_SWD != 0) || (DAP_JTAG != 0))
   uint32_t clock;
   uint32_t delay;
 
-  clock = (*(request+0) <<  0) |
-          (*(request+1) <<  8) |
-          (*(request+2) << 16) |
-          (*(request+3) << 24);
+  clock = (uint32_t)(*(request+0) <<  0) |
+          (uint32_t)(*(request+1) <<  8) |
+          (uint32_t)(*(request+2) << 16) |
+          (uint32_t)(*(request+3) << 24);
 
   if (clock == 0U) {
     *response = DAP_ERROR;
-    return (1U);
+    return ((4U << 16) | 1U);
   }
 
   if (clock >= MAX_SWJ_CLOCK(DELAY_FAST_CYCLES)) {
@@ -384,36 +401,47 @@ static uint32_t DAP_SWJ_Clock(const uint8_t *request, uint8_t *response) {
   }
 
   *response = DAP_OK;
-  return (1U);
-}
+#else
+  *response = DAP_ERROR;
 #endif
+
+  return ((4U << 16) | 1U);
+}
 
 
 // Process SWJ Sequence command and prepare response
 //   request:  pointer to request data
 //   response: pointer to response data
-//   return:   number of bytes in response
-#if ((DAP_SWD != 0) || (DAP_JTAG != 0))
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
 static uint32_t DAP_SWJ_Sequence(const uint8_t *request, uint8_t *response) {
   uint32_t count;
 
   count = *request++;
-  if (count == 0U) { count = 256U; }
+  if (count == 0U) {
+    count = 256U;
+  }
 
+#if ((DAP_SWD != 0) || (DAP_JTAG != 0))
   SWJ_Sequence(count, request);
-
   *response = DAP_OK;
-  return (1U);
-}
+#else
+  *response = DAP_ERROR;
 #endif
+
+  count = (count + 7U) >> 3;
+
+  return (((count + 1U) << 16) | 1U);
+}
 
 
 // Process SWD Configure command and prepare response
 //   request:  pointer to request data
 //   response: pointer to response data
-//   return:   number of bytes in response
-#if (DAP_SWD != 0)
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
 static uint32_t DAP_SWD_Configure(const uint8_t *request, uint8_t *response) {
+#if (DAP_SWD != 0)
   uint8_t value;
 
   value = *request;
@@ -421,52 +449,122 @@ static uint32_t DAP_SWD_Configure(const uint8_t *request, uint8_t *response) {
   DAP_Data.swd_conf.data_phase = (value & 0x04U) ? 1U : 0U;
 
   *response = DAP_OK;
-
-  return (1U);
-}
+#else
+  *response = DAP_ERROR;
 #endif
 
+  return ((1U << 16) | 1U);
+}
 
-// Process JTAG Sequence command and prepare response
+
+// Process SWD Sequence command and prepare response
 //   request:  pointer to request data
 //   response: pointer to response data
-//   return:   number of bytes in response
-#if (DAP_JTAG != 0)
-static uint32_t DAP_JTAG_Sequence(const uint8_t *request, uint8_t *response) {
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
+static uint32_t DAP_SWD_Sequence(const uint8_t *request, uint8_t *response) {
   uint32_t sequence_info;
   uint32_t sequence_count;
+  uint32_t request_count;
   uint32_t response_count;
   uint32_t count;
 
+#if (DAP_SWD != 0)
   *response++ = DAP_OK;
+#else
+  *response++ = DAP_ERROR;
+#endif
+  request_count  = 1U;
   response_count = 1U;
 
   sequence_count = *request++;
   while (sequence_count--) {
     sequence_info = *request++;
-    JTAG_Sequence(sequence_info, request, response);
-    count = sequence_info & JTAG_SEQUENCE_TCK;
-    if (count == 0U) { count = 64U; }
+    count = sequence_info & SWD_SEQUENCE_CLK;
+    if (count == 0U) {
+      count = 64U;
+    }
     count = (count + 7U) / 8U;
-    request += count;
-    if (sequence_info & JTAG_SEQUENCE_TDO) {
+#if (DAP_SWD != 0)
+    if ((sequence_info & SWD_SEQUENCE_DIN) != 0U) {
+      PIN_SWDIO_OUT_DISABLE();
+    } else {
+      PIN_SWDIO_OUT_ENABLE();
+    }
+    SWD_Sequence(sequence_info, request, response);
+    if (sequence_count == 0U) {
+      PIN_SWDIO_OUT_ENABLE();
+    }
+#endif
+    if ((sequence_info & SWD_SEQUENCE_DIN) != 0U) {
+      request_count++;
+#if (DAP_SWD != 0)
       response += count;
       response_count += count;
+#endif
+    } else {
+      request += count;
+      request_count += count + 1U;
     }
   }
 
-  return (response_count);
+  return ((request_count << 16) | response_count);
 }
+
+
+// Process JTAG Sequence command and prepare response
+//   request:  pointer to request data
+//   response: pointer to response data
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
+static uint32_t DAP_JTAG_Sequence(const uint8_t *request, uint8_t *response) {
+  uint32_t sequence_info;
+  uint32_t sequence_count;
+  uint32_t request_count;
+  uint32_t response_count;
+  uint32_t count;
+
+#if (DAP_JTAG != 0)
+  *response++ = DAP_OK;
+#else
+  *response++ = DAP_ERROR;
 #endif
+  request_count  = 1U;
+  response_count = 1U;
+
+  sequence_count = *request++;
+  while (sequence_count--) {
+    sequence_info = *request++;
+    count = sequence_info & JTAG_SEQUENCE_TCK;
+    if (count == 0U) {
+      count = 64U;
+    }
+    count = (count + 7U) / 8U;
+#if (DAP_JTAG != 0)
+    JTAG_Sequence(sequence_info, request, response);
+#endif
+    request += count;
+    request_count += count + 1U;
+#if (DAP_JTAG != 0)
+    if ((sequence_info & JTAG_SEQUENCE_TDO) != 0U) {
+      response += count;
+      response_count += count;
+    }
+#endif
+  }
+
+  return ((request_count << 16) | response_count);
+}
 
 
 // Process JTAG Configure command and prepare response
 //   request:  pointer to request data
 //   response: pointer to response data
-//   return:   number of bytes in response
-#if (DAP_JTAG != 0)
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
 static uint32_t DAP_JTAG_Configure(const uint8_t *request, uint8_t *response) {
   uint32_t count;
+#if (DAP_JTAG != 0)
   uint32_t length;
   uint32_t bits;
   uint32_t n;
@@ -487,28 +585,32 @@ static uint32_t DAP_JTAG_Configure(const uint8_t *request, uint8_t *response) {
   }
 
   *response = DAP_OK;
-  return (1U);
-}
+#else
+  count = *request;
+  *response = DAP_ERROR;
 #endif
+
+  return (((count + 1U) << 16) | 1U);
+}
 
 
 // Process JTAG IDCODE command and prepare response
 //   request:  pointer to request data
 //   response: pointer to response data
-//   return:   number of bytes in response
-#if (DAP_JTAG != 0)
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
 static uint32_t DAP_JTAG_IDCode(const uint8_t *request, uint8_t *response) {
+#if (DAP_JTAG != 0)
   uint32_t data;
 
   if (DAP_Data.debug_port != DAP_PORT_JTAG) {
-err:*response = DAP_ERROR;
-    return (1U);
+    goto id_error;
   }
 
   // Device index (JTAP TAP)
   DAP_Data.jtag_dev.index = *request;
   if (DAP_Data.jtag_dev.index >= DAP_Data.jtag_dev.count) {
-    goto err;
+    goto id_error;
   }
 
   // Select JTAG chain
@@ -524,33 +626,43 @@ err:*response = DAP_ERROR;
   *(response+3) = (uint8_t)(data >> 16);
   *(response+4) = (uint8_t)(data >> 24);
 
-  return (5U);
-}
+  return ((1U << 16) | 5U);
+
+id_error:
 #endif
+  (void)request;
+  *response = DAP_ERROR;
+  return ((1U << 16) | 1U);
+}
 
 
 // Process Transfer Configure command and prepare response
 //   request:  pointer to request data
 //   response: pointer to response data
-//   return:   number of bytes in response
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
 static uint32_t DAP_TransferConfigure(const uint8_t *request, uint8_t *response) {
 
-  DAP_Data.transfer.idle_cycles = *(request+0);
-  DAP_Data.transfer.retry_count = *(request+1) | (*(request+2) << 8);
-  DAP_Data.transfer.match_retry = *(request+3) | (*(request+4) << 8);
+  DAP_Data.transfer.idle_cycles =            *(request+0);
+  DAP_Data.transfer.retry_count = (uint16_t) *(request+1) |
+                                  (uint16_t)(*(request+2) << 8);
+  DAP_Data.transfer.match_retry = (uint16_t) *(request+3) |
+                                  (uint16_t)(*(request+4) << 8);
 
   *response = DAP_OK;
-
-  return (1U);
+  return ((5U << 16) | 1U);
 }
 
 
 // Process SWD Transfer command and prepare response
 //   request:  pointer to request data
 //   response: pointer to response data
-//   return:   number of bytes in response
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
 #if (DAP_SWD != 0)
 static uint32_t DAP_SWD_Transfer(const uint8_t *request, uint8_t *response) {
+  const
+  uint8_t  *request_head;
   uint32_t  request_count;
   uint32_t  request_value;
   uint8_t  *response_head;
@@ -562,6 +674,11 @@ static uint32_t DAP_SWD_Transfer(const uint8_t *request, uint8_t *response) {
   uint32_t  match_retry;
   uint32_t  retry;
   uint32_t  data;
+#if (TIMESTAMP_CLOCK != 0U)
+  uint32_t  timestamp;
+#endif
+
+  request_head   = request;
 
   response_count = 0U;
   response_value = 0U;
@@ -576,9 +693,10 @@ static uint32_t DAP_SWD_Transfer(const uint8_t *request, uint8_t *response) {
   request++;            // Ignore DAP index
 
   request_count = *request++;
-  while (request_count--) {
+
+  for (; request_count != 0U; request_count--) {
     request_value = *request++;
-    if (request_value & DAP_TRANSFER_RnW) {
+    if ((request_value & DAP_TRANSFER_RnW) != 0U) {
       // Read register
       if (post_read) {
         // Read was posted before
@@ -595,28 +713,44 @@ static uint32_t DAP_SWD_Transfer(const uint8_t *request, uint8_t *response) {
           } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
           post_read = 0U;
         }
-        if (response_value != DAP_TRANSFER_OK) { break; }
+        if (response_value != DAP_TRANSFER_OK) {
+          break;
+        }
         // Store previous AP data
         *response++ = (uint8_t) data;
         *response++ = (uint8_t)(data >>  8);
         *response++ = (uint8_t)(data >> 16);
         *response++ = (uint8_t)(data >> 24);
+#if (TIMESTAMP_CLOCK != 0U)
+        if (post_read) {
+          // Store Timestamp of next AP read
+          if ((request_value & DAP_TRANSFER_TIMESTAMP) != 0U) {
+            timestamp = DAP_Data.timestamp;
+            *response++ = (uint8_t) timestamp;
+            *response++ = (uint8_t)(timestamp >>  8);
+            *response++ = (uint8_t)(timestamp >> 16);
+            *response++ = (uint8_t)(timestamp >> 24);
+          }
+        }
+#endif
       }
-      if (request_value & DAP_TRANSFER_MATCH_VALUE) {
+      if ((request_value & DAP_TRANSFER_MATCH_VALUE) != 0U) {
         // Read with value match
-        match_value = (*(request+0) <<  0) |
-                      (*(request+1) <<  8) |
-                      (*(request+2) << 16) |
-                      (*(request+3) << 24);
+        match_value = (uint32_t)(*(request+0) <<  0) |
+                      (uint32_t)(*(request+1) <<  8) |
+                      (uint32_t)(*(request+2) << 16) |
+                      (uint32_t)(*(request+3) << 24);
         request += 4;
         match_retry = DAP_Data.transfer.match_retry;
-        if (request_value & DAP_TRANSFER_APnDP) {
+        if ((request_value & DAP_TRANSFER_APnDP) != 0U) {
           // Post AP read
           retry = DAP_Data.transfer.retry_count;
           do {
             response_value = SWD_Transfer(request_value, NULL);
           } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-          if (response_value != DAP_TRANSFER_OK) { break; }
+          if (response_value != DAP_TRANSFER_OK) {
+            break;
+          }
         }
         do {
           // Read register until its value matches or retry counter expires
@@ -624,23 +758,39 @@ static uint32_t DAP_SWD_Transfer(const uint8_t *request, uint8_t *response) {
           do {
             response_value = SWD_Transfer(request_value, &data);
           } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-          if (response_value != DAP_TRANSFER_OK) { break; }
+          if (response_value != DAP_TRANSFER_OK) {
+            break;
+          }
         } while (((data & DAP_Data.transfer.match_mask) != match_value) && match_retry-- && !DAP_TransferAbort);
         if ((data & DAP_Data.transfer.match_mask) != match_value) {
           response_value |= DAP_TRANSFER_MISMATCH;
         }
-        if (response_value != DAP_TRANSFER_OK) { break; }
+        if (response_value != DAP_TRANSFER_OK) {
+          break;
+        }
       } else {
         // Normal read
         retry = DAP_Data.transfer.retry_count;
-        if (request_value & DAP_TRANSFER_APnDP) {
+        if ((request_value & DAP_TRANSFER_APnDP) != 0U) {
           // Read AP register
           if (post_read == 0U) {
             // Post AP read
             do {
               response_value = SWD_Transfer(request_value, NULL);
             } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-            if (response_value != DAP_TRANSFER_OK) { break; }
+            if (response_value != DAP_TRANSFER_OK) {
+              break;
+            }
+#if (TIMESTAMP_CLOCK != 0U)
+            // Store Timestamp
+            if ((request_value & DAP_TRANSFER_TIMESTAMP) != 0U) {
+              timestamp = DAP_Data.timestamp;
+              *response++ = (uint8_t) timestamp;
+              *response++ = (uint8_t)(timestamp >>  8);
+              *response++ = (uint8_t)(timestamp >> 16);
+              *response++ = (uint8_t)(timestamp >> 24);
+            }
+#endif
             post_read = 1U;
           }
         } else {
@@ -648,7 +798,19 @@ static uint32_t DAP_SWD_Transfer(const uint8_t *request, uint8_t *response) {
           do {
             response_value = SWD_Transfer(request_value, &data);
           } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-          if (response_value != DAP_TRANSFER_OK) { break; }
+          if (response_value != DAP_TRANSFER_OK) {
+            break;
+          }
+#if (TIMESTAMP_CLOCK != 0U)
+          // Store Timestamp
+          if ((request_value & DAP_TRANSFER_TIMESTAMP) != 0U) {
+            timestamp = DAP_Data.timestamp;
+            *response++ = (uint8_t) timestamp;
+            *response++ = (uint8_t)(timestamp >>  8);
+            *response++ = (uint8_t)(timestamp >> 16);
+            *response++ = (uint8_t)(timestamp >> 24);
+          }
+#endif
           // Store data
           *response++ = (uint8_t) data;
           *response++ = (uint8_t)(data >>  8);
@@ -665,7 +827,9 @@ static uint32_t DAP_SWD_Transfer(const uint8_t *request, uint8_t *response) {
         do {
           response_value = SWD_Transfer(DP_RDBUFF | DAP_TRANSFER_RnW, &data);
         } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-        if (response_value != DAP_TRANSFER_OK) { break; }
+        if (response_value != DAP_TRANSFER_OK) {
+          break;
+        }
         // Store previous data
         *response++ = (uint8_t) data;
         *response++ = (uint8_t)(data >>  8);
@@ -674,12 +838,12 @@ static uint32_t DAP_SWD_Transfer(const uint8_t *request, uint8_t *response) {
         post_read = 0U;
       }
       // Load data
-      data = (*(request+0) <<  0) |
-             (*(request+1) <<  8) |
-             (*(request+2) << 16) |
-             (*(request+3) << 24);
+      data = (uint32_t)(*(request+0) <<  0) |
+             (uint32_t)(*(request+1) <<  8) |
+             (uint32_t)(*(request+2) << 16) |
+             (uint32_t)(*(request+3) << 24);
       request += 4;
-      if (request_value & DAP_TRANSFER_MATCH_MASK) {
+      if ((request_value & DAP_TRANSFER_MATCH_MASK) != 0U) {
         // Write match mask
         DAP_Data.transfer.match_mask = data;
         response_value = DAP_TRANSFER_OK;
@@ -689,12 +853,41 @@ static uint32_t DAP_SWD_Transfer(const uint8_t *request, uint8_t *response) {
         do {
           response_value = SWD_Transfer(request_value, &data);
         } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-        if (response_value != DAP_TRANSFER_OK) { break; }
+        if (response_value != DAP_TRANSFER_OK) {
+          break;
+        }
+#if (TIMESTAMP_CLOCK != 0U)
+        // Store Timestamp
+        if ((request_value & DAP_TRANSFER_TIMESTAMP) != 0U) {
+          timestamp = DAP_Data.timestamp;
+          *response++ = (uint8_t) timestamp;
+          *response++ = (uint8_t)(timestamp >>  8);
+          *response++ = (uint8_t)(timestamp >> 16);
+          *response++ = (uint8_t)(timestamp >> 24);
+        }
+#endif
         check_write = 1U;
       }
     }
     response_count++;
-    if (DAP_TransferAbort) { break; }
+    if (DAP_TransferAbort) {
+      break;
+    }
+  }
+
+  for (; request_count != 0U; request_count--) {
+    // Process canceled requests
+    request_value = *request++;
+    if ((request_value & DAP_TRANSFER_RnW) != 0U) {
+      // Read register
+      if ((request_value & DAP_TRANSFER_MATCH_VALUE) != 0U) {
+        // Read with value match
+        request += 4;
+      }
+    } else {
+      // Write register
+      request += 4;
+    }
   }
 
   if (response_value == DAP_TRANSFER_OK) {
@@ -704,7 +897,9 @@ static uint32_t DAP_SWD_Transfer(const uint8_t *request, uint8_t *response) {
       do {
         response_value = SWD_Transfer(DP_RDBUFF | DAP_TRANSFER_RnW, &data);
       } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-      if (response_value != DAP_TRANSFER_OK) { goto end; }
+      if (response_value != DAP_TRANSFER_OK) {
+        goto end;
+      }
       // Store previous data
       *response++ = (uint8_t) data;
       *response++ = (uint8_t)(data >>  8);
@@ -723,7 +918,7 @@ end:
   *(response_head+0) = (uint8_t)response_count;
   *(response_head+1) = (uint8_t)response_value;
 
-  return (response - response_head);
+  return (((uint32_t)(request - request_head) << 16) | (uint32_t)(response - response_head));
 }
 #endif
 
@@ -731,9 +926,12 @@ end:
 // Process JTAG Transfer command and prepare response
 //   request:  pointer to request data
 //   response: pointer to response data
-//   return:   number of bytes in response
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
 #if (DAP_JTAG != 0)
 static uint32_t DAP_JTAG_Transfer(const uint8_t *request, uint8_t *response) {
+  const
+  uint8_t  *request_head;
   uint32_t  request_count;
   uint32_t  request_value;
   uint32_t  request_ir;
@@ -746,6 +944,11 @@ static uint32_t DAP_JTAG_Transfer(const uint8_t *request, uint8_t *response) {
   uint32_t  retry;
   uint32_t  data;
   uint32_t  ir;
+#if (TIMESTAMP_CLOCK != 0U)
+  uint32_t  timestamp;
+#endif
+
+  request_head   = request;
 
   response_count = 0U;
   response_value = 0U;
@@ -759,13 +962,16 @@ static uint32_t DAP_JTAG_Transfer(const uint8_t *request, uint8_t *response) {
 
   // Device index (JTAP TAP)
   DAP_Data.jtag_dev.index = *request++;
-  if (DAP_Data.jtag_dev.index >= DAP_Data.jtag_dev.count) { goto end; }
+  if (DAP_Data.jtag_dev.index >= DAP_Data.jtag_dev.count) {
+    goto end;
+  }
 
   request_count = *request++;
-  while (request_count--) {
+
+  for (; request_count != 0U; request_count--) {
     request_value = *request++;
     request_ir = (request_value & DAP_TRANSFER_APnDP) ? JTAG_APACC : JTAG_DPACC;
-    if (request_value & DAP_TRANSFER_RnW) {
+    if ((request_value & DAP_TRANSFER_RnW) != 0U) {
       // Read register
       if (post_read) {
         // Read was posted before
@@ -787,19 +993,33 @@ static uint32_t DAP_JTAG_Transfer(const uint8_t *request, uint8_t *response) {
           } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
           post_read = 0U;
         }
-        if (response_value != DAP_TRANSFER_OK) { break; }
+        if (response_value != DAP_TRANSFER_OK) {
+          break;
+        }
         // Store previous data
         *response++ = (uint8_t) data;
         *response++ = (uint8_t)(data >>  8);
         *response++ = (uint8_t)(data >> 16);
         *response++ = (uint8_t)(data >> 24);
+#if (TIMESTAMP_CLOCK != 0U)
+        if (post_read) {
+          // Store Timestamp of next AP read
+          if ((request_value & DAP_TRANSFER_TIMESTAMP) != 0U) {
+            timestamp = DAP_Data.timestamp;
+            *response++ = (uint8_t) timestamp;
+            *response++ = (uint8_t)(timestamp >>  8);
+            *response++ = (uint8_t)(timestamp >> 16);
+            *response++ = (uint8_t)(timestamp >> 24);
+          }
+        }
+#endif
       }
-      if (request_value & DAP_TRANSFER_MATCH_VALUE) {
+      if ((request_value & DAP_TRANSFER_MATCH_VALUE) != 0U) {
         // Read with value match
-        match_value = (*(request+0) <<  0) |
-                      (*(request+1) <<  8) |
-                      (*(request+2) << 16) |
-                      (*(request+3) << 24);
+        match_value = (uint32_t)(*(request+0) <<  0) |
+                      (uint32_t)(*(request+1) <<  8) |
+                      (uint32_t)(*(request+2) << 16) |
+                      (uint32_t)(*(request+3) << 24);
         request += 4;
         match_retry  = DAP_Data.transfer.match_retry;
         // Select JTAG chain
@@ -812,19 +1032,25 @@ static uint32_t DAP_JTAG_Transfer(const uint8_t *request, uint8_t *response) {
         do {
           response_value = JTAG_Transfer(request_value, NULL);
         } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-        if (response_value != DAP_TRANSFER_OK) { break; }
+        if (response_value != DAP_TRANSFER_OK) {
+          break;
+        }
         do {
           // Read register until its value matches or retry counter expires
           retry = DAP_Data.transfer.retry_count;
           do {
             response_value = JTAG_Transfer(request_value, &data);
           } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-          if (response_value != DAP_TRANSFER_OK) { break; }
+          if (response_value != DAP_TRANSFER_OK) {
+            break;
+          }
         } while (((data & DAP_Data.transfer.match_mask) != match_value) && match_retry-- && !DAP_TransferAbort);
         if ((data & DAP_Data.transfer.match_mask) != match_value) {
           response_value |= DAP_TRANSFER_MISMATCH;
         }
-        if (response_value != DAP_TRANSFER_OK) { break; }
+        if (response_value != DAP_TRANSFER_OK) {
+          break;
+        }
       } else {
         // Normal read
         if (post_read == 0U) {
@@ -838,7 +1064,19 @@ static uint32_t DAP_JTAG_Transfer(const uint8_t *request, uint8_t *response) {
           do {
             response_value = JTAG_Transfer(request_value, NULL);
           } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-          if (response_value != DAP_TRANSFER_OK) { break; }
+          if (response_value != DAP_TRANSFER_OK) {
+            break;
+          }
+#if (TIMESTAMP_CLOCK != 0U)
+          // Store Timestamp
+          if ((request_value & DAP_TRANSFER_TIMESTAMP) != 0U) {
+            timestamp = DAP_Data.timestamp;
+            *response++ = (uint8_t) timestamp;
+            *response++ = (uint8_t)(timestamp >>  8);
+            *response++ = (uint8_t)(timestamp >> 16);
+            *response++ = (uint8_t)(timestamp >> 24);
+          }
+#endif
           post_read = 1U;
         }
       }
@@ -855,7 +1093,9 @@ static uint32_t DAP_JTAG_Transfer(const uint8_t *request, uint8_t *response) {
         do {
           response_value = JTAG_Transfer(DP_RDBUFF | DAP_TRANSFER_RnW, &data);
         } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-        if (response_value != DAP_TRANSFER_OK) { break; }
+        if (response_value != DAP_TRANSFER_OK) {
+          break;
+        }
         // Store previous data
         *response++ = (uint8_t) data;
         *response++ = (uint8_t)(data >>  8);
@@ -864,12 +1104,12 @@ static uint32_t DAP_JTAG_Transfer(const uint8_t *request, uint8_t *response) {
         post_read = 0U;
       }
       // Load data
-      data = (*(request+0) <<  0) |
-             (*(request+1) <<  8) |
-             (*(request+2) << 16) |
-             (*(request+3) << 24);
+      data = (uint32_t)(*(request+0) <<  0) |
+             (uint32_t)(*(request+1) <<  8) |
+             (uint32_t)(*(request+2) << 16) |
+             (uint32_t)(*(request+3) << 24);
       request += 4;
-      if (request_value & DAP_TRANSFER_MATCH_MASK) {
+      if ((request_value & DAP_TRANSFER_MATCH_MASK) != 0U) {
         // Write match mask
         DAP_Data.transfer.match_mask = data;
         response_value = DAP_TRANSFER_OK;
@@ -884,11 +1124,40 @@ static uint32_t DAP_JTAG_Transfer(const uint8_t *request, uint8_t *response) {
         do {
           response_value = JTAG_Transfer(request_value, &data);
         } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-        if (response_value != DAP_TRANSFER_OK) { break; }
+        if (response_value != DAP_TRANSFER_OK) {
+          break;
+        }
+#if (TIMESTAMP_CLOCK != 0U)
+        // Store Timestamp
+        if ((request_value & DAP_TRANSFER_TIMESTAMP) != 0U) {
+          timestamp = DAP_Data.timestamp;
+          *response++ = (uint8_t) timestamp;
+          *response++ = (uint8_t)(timestamp >>  8);
+          *response++ = (uint8_t)(timestamp >> 16);
+          *response++ = (uint8_t)(timestamp >> 24);
+        }
+#endif
       }
     }
     response_count++;
-    if (DAP_TransferAbort) { break; }
+    if (DAP_TransferAbort) {
+      break;
+    }
+  }
+
+  for (; request_count != 0U; request_count--) {
+    // Process canceled requests
+    request_value = *request++;
+    if ((request_value & DAP_TRANSFER_RnW) != 0U) {
+      // Read register
+      if ((request_value & DAP_TRANSFER_MATCH_VALUE) != 0U) {
+        // Read with value match
+        request += 4;
+      }
+    } else {
+      // Write register
+      request += 4;
+    }
   }
 
   if (response_value == DAP_TRANSFER_OK) {
@@ -903,7 +1172,9 @@ static uint32_t DAP_JTAG_Transfer(const uint8_t *request, uint8_t *response) {
       do {
         response_value = JTAG_Transfer(DP_RDBUFF | DAP_TRANSFER_RnW, &data);
       } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-      if (response_value != DAP_TRANSFER_OK) { goto end; }
+      if (response_value != DAP_TRANSFER_OK) {
+        goto end;
+      }
       // Store previous data
       *response++ = (uint8_t) data;
       *response++ = (uint8_t)(data >>  8);
@@ -922,9 +1193,76 @@ end:
   *(response_head+0) = (uint8_t)response_count;
   *(response_head+1) = (uint8_t)response_value;
 
-  return (response - response_head);
+  return (((uint32_t)(request - request_head) << 16) | (uint32_t)(response - response_head));
 }
 #endif
+
+
+// Process Dummy Transfer command and prepare response
+//   request:  pointer to request data
+//   response: pointer to response data
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
+static uint32_t DAP_Dummy_Transfer(const uint8_t *request, uint8_t *response) {
+  const
+  uint8_t  *request_head;
+  uint32_t  request_count;
+  uint32_t  request_value;
+
+  request_head  =  request;
+
+  request++;            // Ignore DAP index
+
+  request_count = *request++;
+
+  for (; request_count != 0U; request_count--) {
+    // Process dummy requests
+    request_value = *request++;
+    if ((request_value & DAP_TRANSFER_RnW) != 0U) {
+      // Read register
+      if ((request_value & DAP_TRANSFER_MATCH_VALUE) != 0U) {
+        // Read with value match
+        request += 4;
+      }
+    } else {
+      // Write register
+      request += 4;
+    }
+  }
+
+  *(response+0) = 0U;   // Response count
+  *(response+1) = 0U;   // Response value
+
+  return (((uint32_t)(request - request_head) << 16) | 2U);
+}
+
+
+// Process Transfer command and prepare response
+//   request:  pointer to request data
+//   response: pointer to response data
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
+static uint32_t DAP_Transfer(const uint8_t *request, uint8_t *response) {
+  uint32_t num;
+
+  switch (DAP_Data.debug_port) {
+#if (DAP_SWD != 0)
+    case DAP_PORT_SWD:
+      num = DAP_SWD_Transfer(request, response);
+      break;
+#endif
+#if (DAP_JTAG != 0)
+    case DAP_PORT_JTAG:
+      num = DAP_JTAG_Transfer(request, response);
+      break;
+#endif
+    default:
+      num = DAP_Dummy_Transfer(request, response);
+      break;
+  }
+
+  return (num);
+}
 
 
 // Process SWD Transfer Block command and prepare response
@@ -950,24 +1288,29 @@ static uint32_t DAP_SWD_TransferBlock(const uint8_t *request, uint8_t *response)
 
   request++;            // Ignore DAP index
 
-  request_count = *request | (*(request+1) << 8);
+  request_count = (uint32_t)(*(request+0) << 0) |
+                  (uint32_t)(*(request+1) << 8);
   request += 2;
-  if (request_count == 0U) { goto end; }
+  if (request_count == 0U) {
+    goto end;
+  }
 
   request_value = *request++;
-  if (request_value & DAP_TRANSFER_RnW) {
+  if ((request_value & DAP_TRANSFER_RnW) != 0U) {
     // Read register block
-    if (request_value & DAP_TRANSFER_APnDP) {
+    if ((request_value & DAP_TRANSFER_APnDP) != 0U) {
       // Post AP read
       retry = DAP_Data.transfer.retry_count;
       do {
         response_value = SWD_Transfer(request_value, NULL);
       } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-      if (response_value != DAP_TRANSFER_OK) { goto end; }
+      if (response_value != DAP_TRANSFER_OK) {
+        goto end;
+      }
     }
     while (request_count--) {
       // Read DP/AP register
-      if ((request_count == 0U) && (request_value & DAP_TRANSFER_APnDP)) {
+      if ((request_count == 0U) && ((request_value & DAP_TRANSFER_APnDP) != 0U)) {
         // Last AP read
         request_value = DP_RDBUFF | DAP_TRANSFER_RnW;
       }
@@ -975,7 +1318,9 @@ static uint32_t DAP_SWD_TransferBlock(const uint8_t *request, uint8_t *response)
       do {
         response_value = SWD_Transfer(request_value, &data);
       } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-      if (response_value != DAP_TRANSFER_OK) { goto end; }
+      if (response_value != DAP_TRANSFER_OK) {
+        goto end;
+      }
       // Store data
       *response++ = (uint8_t) data;
       *response++ = (uint8_t)(data >>  8);
@@ -987,17 +1332,19 @@ static uint32_t DAP_SWD_TransferBlock(const uint8_t *request, uint8_t *response)
     // Write register block
     while (request_count--) {
       // Load data
-      data = (*(request+0) <<  0) |
-             (*(request+1) <<  8) |
-             (*(request+2) << 16) |
-             (*(request+3) << 24);
+      data = (uint32_t)(*(request+0) <<  0) |
+             (uint32_t)(*(request+1) <<  8) |
+             (uint32_t)(*(request+2) << 16) |
+             (uint32_t)(*(request+3) << 24);
       request += 4;
       // Write DP/AP register
       retry = DAP_Data.transfer.retry_count;
       do {
         response_value = SWD_Transfer(request_value, &data);
       } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-      if (response_value != DAP_TRANSFER_OK) { goto end; }
+      if (response_value != DAP_TRANSFER_OK) {
+        goto end;
+      }
       response_count++;
     }
     // Check last write
@@ -1012,7 +1359,7 @@ end:
   *(response_head+1) = (uint8_t)(response_count >> 8);
   *(response_head+2) = (uint8_t) response_value;
 
-  return (response - response_head);
+  return ((uint32_t)(response - response_head));
 }
 #endif
 
@@ -1041,11 +1388,16 @@ static uint32_t DAP_JTAG_TransferBlock(const uint8_t *request, uint8_t *response
 
   // Device index (JTAP TAP)
   DAP_Data.jtag_dev.index = *request++;
-  if (DAP_Data.jtag_dev.index >= DAP_Data.jtag_dev.count) { goto end; }
+  if (DAP_Data.jtag_dev.index >= DAP_Data.jtag_dev.count) {
+    goto end;
+  }
 
-  request_count = *request | (*(request+1) << 8);
+  request_count = (uint32_t)(*(request+0) << 0) |
+                  (uint32_t)(*(request+1) << 8);
   request += 2;
-  if (request_count == 0U) { goto end; }
+  if (request_count == 0U) {
+    goto end;
+  }
 
   request_value = *request++;
 
@@ -1053,13 +1405,15 @@ static uint32_t DAP_JTAG_TransferBlock(const uint8_t *request, uint8_t *response
   ir = (request_value & DAP_TRANSFER_APnDP) ? JTAG_APACC : JTAG_DPACC;
   JTAG_IR(ir);
 
-  if (request_value & DAP_TRANSFER_RnW) {
+  if ((request_value & DAP_TRANSFER_RnW) != 0U) {
     // Post read
     retry = DAP_Data.transfer.retry_count;
     do {
       response_value = JTAG_Transfer(request_value, NULL);
     } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-    if (response_value != DAP_TRANSFER_OK) { goto end; }
+    if (response_value != DAP_TRANSFER_OK) {
+      goto end;
+    }
     // Read register block
     while (request_count--) {
       // Read DP/AP register
@@ -1074,7 +1428,9 @@ static uint32_t DAP_JTAG_TransferBlock(const uint8_t *request, uint8_t *response
       do {
         response_value = JTAG_Transfer(request_value, &data);
       } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-      if (response_value != DAP_TRANSFER_OK) { goto end; }
+      if (response_value != DAP_TRANSFER_OK) {
+        goto end;
+      }
       // Store data
       *response++ = (uint8_t) data;
       *response++ = (uint8_t)(data >>  8);
@@ -1086,17 +1442,19 @@ static uint32_t DAP_JTAG_TransferBlock(const uint8_t *request, uint8_t *response
     // Write register block
     while (request_count--) {
       // Load data
-      data = (*(request+0) <<  0) |
-             (*(request+1) <<  8) |
-             (*(request+2) << 16) |
-             (*(request+3) << 24);
+      data = (uint32_t)(*(request+0) <<  0) |
+             (uint32_t)(*(request+1) <<  8) |
+             (uint32_t)(*(request+2) << 16) |
+             (uint32_t)(*(request+3) << 24);
       request += 4;
       // Write DP/AP register
       retry = DAP_Data.transfer.retry_count;
       do {
         response_value = JTAG_Transfer(request_value, &data);
       } while ((response_value == DAP_TRANSFER_WAIT) && retry-- && !DAP_TransferAbort);
-      if (response_value != DAP_TRANSFER_OK) { goto end; }
+      if (response_value != DAP_TRANSFER_OK) {
+        goto end;
+      }
       response_count++;
     }
     // Check last write
@@ -1114,29 +1472,63 @@ end:
   *(response_head+1) = (uint8_t)(response_count >> 8);
   *(response_head+2) = (uint8_t) response_value;
 
-  return (response - response_head);
+  return ((uint32_t)(response - response_head));
 }
 #endif
 
 
-// Process SWD Abort command and prepare response
+// Process Transfer Block command and prepare response
+//   request:  pointer to request data
+//   response: pointer to response data
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
+static uint32_t DAP_TransferBlock(const uint8_t *request, uint8_t *response) {
+  uint32_t num;
+
+  switch (DAP_Data.debug_port) {
+#if (DAP_SWD != 0)
+    case DAP_PORT_SWD:
+      num = DAP_SWD_TransferBlock (request, response);
+      break;
+#endif
+#if (DAP_JTAG != 0)
+    case DAP_PORT_JTAG:
+      num = DAP_JTAG_TransferBlock(request, response);
+      break;
+#endif
+    default:
+      *(response+0) = 0U;       // Response count [7:0]
+      *(response+1) = 0U;       // Response count[15:8]
+      *(response+2) = 0U;       // Response value
+      num = 3U;
+      break;
+  }
+
+  if ((*(request+3) & DAP_TRANSFER_RnW) != 0U) {
+    // Read register block
+    num |=  4U << 16;
+  } else {
+    // Write register block
+    num |= (4U + (((uint32_t)(*(request+1)) | (uint32_t)(*(request+2) << 8)) * 4)) << 16;
+  }
+
+  return (num);
+}
+
+
+// Process SWD Write ABORT command and prepare response
 //   request:  pointer to request data
 //   response: pointer to response data
 //   return:   number of bytes in response
 #if (DAP_SWD != 0)
-static uint32_t DAP_SWD_Abort(const uint8_t *request, uint8_t *response) {
+static uint32_t DAP_SWD_WriteAbort(const uint8_t *request, uint8_t *response) {
   uint32_t data;
 
-  if (DAP_Data.debug_port != DAP_PORT_SWD) {
-    *response = DAP_ERROR;
-    return (1U);
-  }
-
   // Load data (Ignore DAP index)
-  data = (*(request+1) <<  0) |
-         (*(request+2) <<  8) |
-         (*(request+3) << 16) |
-         (*(request+4) << 24);
+  data = (uint32_t)(*(request+1) <<  0) |
+         (uint32_t)(*(request+2) <<  8) |
+         (uint32_t)(*(request+3) << 16) |
+         (uint32_t)(*(request+4) << 24);
 
   // Write Abort register
   SWD_Transfer(DP_ABORT, &data);
@@ -1147,33 +1539,29 @@ static uint32_t DAP_SWD_Abort(const uint8_t *request, uint8_t *response) {
 #endif
 
 
-// Process JTAG Abort command and prepare response
+// Process JTAG Write ABORT command and prepare response
 //   request:  pointer to request data
 //   response: pointer to response data
 //   return:   number of bytes in response
 #if (DAP_JTAG != 0)
-static uint32_t DAP_JTAG_Abort(uint8_t *request, uint8_t *response) {
+static uint32_t DAP_JTAG_WriteAbort(const uint8_t *request, uint8_t *response) {
   uint32_t data;
-
-  if (DAP_Data.debug_port != DAP_PORT_JTAG) {
-err:*response = DAP_ERROR;
-    return (1U);
-  }
 
   // Device index (JTAP TAP)
   DAP_Data.jtag_dev.index = *request;
   if (DAP_Data.jtag_dev.index >= DAP_Data.jtag_dev.count) {
-    goto err;
+    *response = DAP_ERROR;
+    return (1U);
   }
 
   // Select JTAG chain
   JTAG_IR(JTAG_ABORT);
 
   // Load data
-  data = (*(request+1) <<  0) |
-         (*(request+2) <<  8) |
-         (*(request+3) << 16) |
-         (*(request+4) << 24);
+  data = (uint32_t)(*(request+1) <<  0) |
+         (uint32_t)(*(request+2) <<  8) |
+         (uint32_t)(*(request+3) << 16) |
+         (uint32_t)(*(request+4) << 24);
 
   // Write Abort register
   JTAG_WriteAbort(data);
@@ -1184,22 +1572,52 @@ err:*response = DAP_ERROR;
 #endif
 
 
-// Process DAP Vendor command and prepare response
-// Default function (can be overridden)
+// Process Write ABORT command and prepare response
 //   request:  pointer to request data
 //   response: pointer to response data
-//   return:   number of bytes in response
-__weak uint32_t DAP_ProcessVendorCommand(const uint8_t *request, uint8_t *response) {
-  (void)request;
-  *response = ID_DAP_Invalid;
-  return (1U);
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
+static uint32_t DAP_WriteAbort(const uint8_t *request, uint8_t *response) {
+  uint32_t num;
+
+  switch (DAP_Data.debug_port) {
+#if (DAP_SWD != 0)
+    case DAP_PORT_SWD:
+      num = DAP_SWD_WriteAbort (request, response);
+      break;
+#endif
+#if (DAP_JTAG != 0)
+    case DAP_PORT_JTAG:
+      num = DAP_JTAG_WriteAbort(request, response);
+      break;
+#endif
+    default:
+      *response = DAP_ERROR;
+      num = 1U;
+      break;
+  }
+  return ((5U << 16) | num);
 }
 
 
-// Process DAP command and prepare response
+// Process DAP Vendor command request and prepare response
+// Default function (can be overridden)
 //   request:  pointer to request data
 //   response: pointer to response data
-//   return:   number of bytes in response
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
+__weak uint32_t DAP_ProcessVendorCommand(const uint8_t *request, uint8_t *response) {
+  (void)request;
+  *response = ID_DAP_Invalid;
+  return ((1U << 16) | 1U);
+}
+
+
+// Process DAP command request and prepare response
+//   request:  pointer to request data
+//   response: pointer to response data
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
 uint32_t DAP_ProcessCommand(const uint8_t *request, uint8_t *response) {
   uint32_t num;
 
@@ -1213,17 +1631,19 @@ uint32_t DAP_ProcessCommand(const uint8_t *request, uint8_t *response) {
     case ID_DAP_Info:
       num = DAP_Info(*request, response+1);
       *response = (uint8_t)num;
-      return (2U + num);
+      return ((2U << 16) + 2U + num);
 
     case ID_DAP_HostStatus:
       num = DAP_HostStatus(request, response);
       break;
+
     case ID_DAP_Connect:
       num = DAP_Connect(request, response);
       break;
     case ID_DAP_Disconnect:
       num = DAP_Disconnect(response);
       break;
+
     case ID_DAP_Delay:
       num = DAP_Delay(request, response);
       break;
@@ -1232,7 +1652,6 @@ uint32_t DAP_ProcessCommand(const uint8_t *request, uint8_t *response) {
       num = DAP_ResetTarget(response);
       break;
 
-#if ((DAP_SWD != 0) || (DAP_JTAG != 0))
     case ID_DAP_SWJ_Pins:
       num = DAP_SWJ_Pins(request, response);
       break;
@@ -1242,25 +1661,14 @@ uint32_t DAP_ProcessCommand(const uint8_t *request, uint8_t *response) {
     case ID_DAP_SWJ_Sequence:
       num = DAP_SWJ_Sequence(request, response);
       break;
-#else
-    case ID_DAP_SWJ_Pins:
-    case ID_DAP_SWJ_Clock:
-    case ID_DAP_SWJ_Sequence:
-      *response = DAP_ERROR;
-      return (2U);
-#endif
 
-#if (DAP_SWD != 0)
     case ID_DAP_SWD_Configure:
       num = DAP_SWD_Configure(request, response);
       break;
-#else
-    case ID_DAP_SWD_Configure:
-      *response = DAP_ERROR;
-      return (2U);
-#endif
+    case ID_DAP_SWD_Sequence:
+      num = DAP_SWD_Sequence(request, response);
+      break;
 
-#if (DAP_JTAG != 0)
     case ID_DAP_JTAG_Sequence:
       num = DAP_JTAG_Sequence(request, response);
       break;
@@ -1270,81 +1678,77 @@ uint32_t DAP_ProcessCommand(const uint8_t *request, uint8_t *response) {
     case ID_DAP_JTAG_IDCODE:
       num = DAP_JTAG_IDCode(request, response);
       break;
-#else
-    case ID_DAP_JTAG_Sequence:
-    case ID_DAP_JTAG_Configure:
-    case ID_DAP_JTAG_IDCODE:
-      *response = DAP_ERROR;
-      return (2U);
-#endif
 
     case ID_DAP_TransferConfigure:
       num = DAP_TransferConfigure(request, response);
       break;
-
     case ID_DAP_Transfer:
-      switch (DAP_Data.debug_port) {
-#if (DAP_SWD != 0)
-        case DAP_PORT_SWD:
-          num = DAP_SWD_Transfer (request, response);
-          break;
-#endif
-#if (DAP_JTAG != 0)
-        case DAP_PORT_JTAG:
-          num = DAP_JTAG_Transfer(request, response);
-          break;
-#endif
-        default:
-          *(response+0) = 0U;    // Response count
-          *(response+1) = 0U;    // Response value
-          num = 2;
-      }
+      num = DAP_Transfer(request, response);
       break;
-
     case ID_DAP_TransferBlock:
-      switch (DAP_Data.debug_port) {
-#if (DAP_SWD != 0)
-        case DAP_PORT_SWD:
-          num = DAP_SWD_TransferBlock (request, response);
-          break;
-#endif
-#if (DAP_JTAG != 0)
-        case DAP_PORT_JTAG:
-          num = DAP_JTAG_TransferBlock(request, response);
-          break;
-#endif
-        default:
-          *(response+0) = 0U;    // Response count [7:0]
-          *(response+1) = 0U;    // Response count[15:8]
-          *(response+2) = 0U;    // Response value
-          num = 3;
-      }
+      num = DAP_TransferBlock(request, response);
       break;
 
     case ID_DAP_WriteABORT:
-      switch (DAP_Data.debug_port) {
-#if (DAP_SWD != 0)
-        case DAP_PORT_SWD:
-          num = DAP_SWD_Abort (request, response);
-          break;
-#endif
-#if (DAP_JTAG != 0)
-        case DAP_PORT_JTAG:
-          num = DAP_JTAG_Abort(request, response);
-          break;
-#endif
-        default:
-          *response = DAP_ERROR;
-          return (2U);
-      }
+      num = DAP_WriteAbort(request, response);
       break;
+
+#if ((SWO_UART != 0) || (SWO_MANCHESTER != 0))
+    case ID_DAP_SWO_Transport:
+      num = SWO_Transport(request, response);
+      break;
+    case ID_DAP_SWO_Mode:
+      num = SWO_Mode(request, response);
+      break;
+    case ID_DAP_SWO_Baudrate:
+      num = SWO_Baudrate(request, response);
+      break;
+    case ID_DAP_SWO_Control:
+      num = SWO_Control(request, response);
+      break;
+    case ID_DAP_SWO_Status:
+      num = SWO_Status(response);
+      break;
+    case ID_DAP_SWO_ExtendedStatus:
+      num = SWO_ExtendedStatus(request, response);
+      break;
+    case ID_DAP_SWO_Data:
+      num = SWO_Data(request, response);
+      break;
+#endif
 
     default:
       *(response-1) = ID_DAP_Invalid;
-      return (1U);
+      return ((1U << 16) | 1U);
   }
 
-  return (1U + num);
+  return ((1U << 16) + 1U + num);
+}
+
+
+// Execute DAP command (process request and prepare response)
+//   request:  pointer to request data
+//   response: pointer to response data
+//   return:   number of bytes in response (lower 16 bits)
+//             number of bytes in request (upper 16 bits)
+uint32_t DAP_ExecuteCommand(const uint8_t *request, uint8_t *response) {
+  uint32_t cnt, num, n;
+
+  if (*request == ID_DAP_ExecuteCommands) {
+    *response++ = *request++;
+    cnt = *request++;
+    *response++ = (uint8_t)cnt;
+    num = (2U << 16) | 2U;
+    while (cnt--) {
+      n = DAP_ProcessCommand(request, response);
+      num += n;
+      request  += (uint16_t)(n >> 16);
+      response += (uint16_t) n;
+    }
+    return (num);
+  }
+
+  return DAP_ProcessCommand(request, response);
 }
 
 

--- a/src/DAP/CMSIS_DAP.h
+++ b/src/DAP/CMSIS_DAP.h
@@ -1,22 +1,40 @@
 /* CMSIS-DAP Interface Firmware
- * Copyright (c) 2009-2013 ARM Limited
+ * Copyright (c) 2013-2017 ARM Limited. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        1. December 2017
+ * $Revision:    V2.0.0
+ *
+ * Project:      CMSIS-DAP Include
+ * Title:        DAP.h Definitions
+ *
+ *---------------------------------------------------------------------------*/
 
 #ifndef __DAP_H__
 #define __DAP_H__
 
+
+// DAP Firmware Version
+#ifdef  DAP_FW_V1
+#define DAP_FW_VER                      "1.2.0"
+#else
+#define DAP_FW_VER                      "2.0.0"
+#endif
 
 // DAP Command IDs
 #define ID_DAP_Info                     0x00U
@@ -34,9 +52,20 @@
 #define ID_DAP_SWJ_Clock                0x11U
 #define ID_DAP_SWJ_Sequence             0x12U
 #define ID_DAP_SWD_Configure            0x13U
+#define ID_DAP_SWD_Sequence             0x1DU
 #define ID_DAP_JTAG_Sequence            0x14U
 #define ID_DAP_JTAG_Configure           0x15U
 #define ID_DAP_JTAG_IDCODE              0x16U
+#define ID_DAP_SWO_Transport            0x17U
+#define ID_DAP_SWO_Mode                 0x18U
+#define ID_DAP_SWO_Baudrate             0x19U
+#define ID_DAP_SWO_Control              0x1AU
+#define ID_DAP_SWO_Status               0x1BU
+#define ID_DAP_SWO_ExtendedStatus       0x1EU
+#define ID_DAP_SWO_Data                 0x1CU
+
+#define ID_DAP_QueueCommands            0x7EU
+#define ID_DAP_ExecuteCommands          0x7FU
 
 // DAP Vendor Command IDs
 #define ID_DAP_Vendor0                  0x80U
@@ -86,6 +115,8 @@
 #define DAP_ID_DEVICE_VENDOR            5U
 #define DAP_ID_DEVICE_NAME              6U
 #define DAP_ID_CAPABILITIES             0xF0U
+#define DAP_ID_TIMESTAMP_CLOCK          0xF1U
+#define DAP_ID_SWO_BUFFER_SIZE          0xFDU
 #define DAP_ID_PACKET_COUNT             0xFEU
 #define DAP_ID_PACKET_SIZE              0xFFU
 
@@ -114,6 +145,7 @@
 #define DAP_TRANSFER_A3                 (1U<<3)
 #define DAP_TRANSFER_MATCH_VALUE        (1U<<4)
 #define DAP_TRANSFER_MATCH_MASK         (1U<<5)
+#define DAP_TRANSFER_TIMESTAMP          (1U<<7)
 
 // DAP Transfer Response
 #define DAP_TRANSFER_OK                 (1U<<0)
@@ -121,6 +153,17 @@
 #define DAP_TRANSFER_FAULT              (1U<<2)
 #define DAP_TRANSFER_ERROR              (1U<<3)
 #define DAP_TRANSFER_MISMATCH           (1U<<4)
+
+// DAP SWO Trace Mode
+#define DAP_SWO_OFF                     0U
+#define DAP_SWO_UART                    1U
+#define DAP_SWO_MANCHESTER              2U
+
+// DAP SWO Trace Status
+#define DAP_SWO_CAPTURE_ACTIVE          (1U<<0)
+#define DAP_SWO_CAPTURE_PAUSED          (1U<<1)
+#define DAP_SWO_STREAM_ERROR            (1U<<6)
+#define DAP_SWO_BUFFER_OVERRUN          (1U<<7)
 
 
 // Debug Port Register Addresses
@@ -144,6 +187,9 @@
 #define JTAG_SEQUENCE_TMS               0x40U   // TMS value
 #define JTAG_SEQUENCE_TDO               0x80U   // TDO capture
 
+// SWD Sequence Info
+#define SWD_SEQUENCE_CLK                0x3FU   // SWCLK count
+#define SWD_SEQUENCE_DIN                0x80U   // SWDIO capture
 
 #include <stddef.h>
 #include <stdint.h>
@@ -152,9 +198,12 @@
 typedef struct {
   uint8_t     debug_port;                       // Debug Port
   uint8_t     fast_clock;                       // Fast Clock Flag
+  uint8_t     padding[2];
   uint32_t   clock_delay;                       // Clock Delay
+  uint32_t     timestamp;                       // Last captured Timestamp
   struct {                                      // Transfer Configuration
     uint8_t   idle_cycles;                      // Idle cycles after transfer
+    uint8_t    padding[3];
     uint16_t  retry_count;                      // Number of retries after WAIT response
     uint16_t  match_retry;                      // Number of retries if read value does not match
     uint32_t  match_mask;                       // Match Mask
@@ -184,7 +233,8 @@ extern volatile uint8_t    DAP_TransferAbort;   // Transfer Abort Flag
 
 // Functions
 extern void     SWJ_Sequence    (uint32_t count, const uint8_t *data);
-extern void     JTAG_Sequence   (uint32_t info,  const uint8_t *tdi, uint8_t *tdo);
+extern void     SWD_Sequence    (uint32_t info,  const uint8_t *swdo, uint8_t *swdi);
+extern void     JTAG_Sequence   (uint32_t info,  const uint8_t *tdi,  uint8_t *tdo);
 extern void     JTAG_IR         (uint32_t ir);
 extern uint32_t JTAG_ReadIDCode (void);
 extern void     JTAG_WriteAbort (uint32_t data);
@@ -193,8 +243,33 @@ extern uint8_t  SWD_Transfer    (uint32_t request, uint32_t *data);
 
 extern void     Delayms         (uint32_t delay);
 
+extern uint32_t SWO_Transport      (const uint8_t *request, uint8_t *response);
+extern uint32_t SWO_Mode           (const uint8_t *request, uint8_t *response);
+extern uint32_t SWO_Baudrate       (const uint8_t *request, uint8_t *response);
+extern uint32_t SWO_Control        (const uint8_t *request, uint8_t *response);
+extern uint32_t SWO_Status                                 (uint8_t *response);
+extern uint32_t SWO_ExtendedStatus (const uint8_t *request, uint8_t *response);
+extern uint32_t SWO_Data           (const uint8_t *request, uint8_t *response);
+
+extern void     SWO_QueueTransfer    (uint8_t *buf, uint32_t num);
+extern void     SWO_AbortTransfer    (void);
+extern void     SWO_TransferComplete (void);
+
+extern uint32_t UART_SWO_Mode     (uint32_t enable);
+extern uint32_t UART_SWO_Baudrate (uint32_t baudrate);
+extern uint32_t UART_SWO_Control  (uint32_t active);
+extern void     UART_SWO_Capture  (uint8_t *buf, uint32_t num);
+extern uint32_t UART_SWO_GetCount (void);
+
+extern uint32_t Manchester_SWO_Mode     (uint32_t enable);
+extern uint32_t Manchester_SWO_Baudrate (uint32_t baudrate);
+extern uint32_t Manchester_SWO_Control  (uint32_t active);
+extern void     Manchester_SWO_Capture  (uint8_t *buf, uint32_t num);
+extern uint32_t Manchester_SWO_GetCount (void);
+
 extern uint32_t DAP_ProcessVendorCommand (const uint8_t *request, uint8_t *response);
-extern uint32_t DAP_ProcessCommand (const uint8_t *request, uint8_t *response);
+extern uint32_t DAP_ProcessCommand       (const uint8_t *request, uint8_t *response);
+extern uint32_t DAP_ExecuteCommand       (const uint8_t *request, uint8_t *response);
 
 extern void     DAP_Setup (void);
 

--- a/src/DAP/CMSIS_DAP.h
+++ b/src/DAP/CMSIS_DAP.h
@@ -19,85 +19,85 @@
 
 
 // DAP Command IDs
-#define ID_DAP_Info                     0x00
-#define ID_DAP_HostStatus               0x01
-#define ID_DAP_Connect                  0x02
-#define ID_DAP_Disconnect               0x03
-#define ID_DAP_TransferConfigure        0x04
-#define ID_DAP_Transfer                 0x05
-#define ID_DAP_TransferBlock            0x06
-#define ID_DAP_TransferAbort            0x07
-#define ID_DAP_WriteABORT               0x08
-#define ID_DAP_Delay                    0x09
-#define ID_DAP_ResetTarget              0x0A
-#define ID_DAP_SWJ_Pins                 0x10
-#define ID_DAP_SWJ_Clock                0x11
-#define ID_DAP_SWJ_Sequence             0x12
-#define ID_DAP_SWD_Configure            0x13
-#define ID_DAP_JTAG_Sequence            0x14
-#define ID_DAP_JTAG_Configure           0x15
-#define ID_DAP_JTAG_IDCODE              0x16
+#define ID_DAP_Info                     0x00U
+#define ID_DAP_HostStatus               0x01U
+#define ID_DAP_Connect                  0x02U
+#define ID_DAP_Disconnect               0x03U
+#define ID_DAP_TransferConfigure        0x04U
+#define ID_DAP_Transfer                 0x05U
+#define ID_DAP_TransferBlock            0x06U
+#define ID_DAP_TransferAbort            0x07U
+#define ID_DAP_WriteABORT               0x08U
+#define ID_DAP_Delay                    0x09U
+#define ID_DAP_ResetTarget              0x0AU
+#define ID_DAP_SWJ_Pins                 0x10U
+#define ID_DAP_SWJ_Clock                0x11U
+#define ID_DAP_SWJ_Sequence             0x12U
+#define ID_DAP_SWD_Configure            0x13U
+#define ID_DAP_JTAG_Sequence            0x14U
+#define ID_DAP_JTAG_Configure           0x15U
+#define ID_DAP_JTAG_IDCODE              0x16U
 
 // DAP Vendor Command IDs
-#define ID_DAP_Vendor0                  0x80
-#define ID_DAP_Vendor1                  0x81
-#define ID_DAP_Vendor2                  0x82
-#define ID_DAP_Vendor3                  0x83
-#define ID_DAP_Vendor4                  0x84
-#define ID_DAP_Vendor5                  0x85
-#define ID_DAP_Vendor6                  0x86
-#define ID_DAP_Vendor7                  0x87
-#define ID_DAP_Vendor8                  0x88
-#define ID_DAP_Vendor9                  0x89
-#define ID_DAP_Vendor10                 0x8A
-#define ID_DAP_Vendor11                 0x8B
-#define ID_DAP_Vendor12                 0x8C
-#define ID_DAP_Vendor13                 0x8D
-#define ID_DAP_Vendor14                 0x8E
-#define ID_DAP_Vendor15                 0x8F
-#define ID_DAP_Vendor16                 0x90
-#define ID_DAP_Vendor17                 0x91
-#define ID_DAP_Vendor18                 0x92
-#define ID_DAP_Vendor19                 0x93
-#define ID_DAP_Vendor20                 0x94
-#define ID_DAP_Vendor21                 0x95
-#define ID_DAP_Vendor22                 0x96
-#define ID_DAP_Vendor23                 0x97
-#define ID_DAP_Vendor24                 0x98
-#define ID_DAP_Vendor25                 0x99
-#define ID_DAP_Vendor26                 0x9A
-#define ID_DAP_Vendor27                 0x9B
-#define ID_DAP_Vendor28                 0x9C
-#define ID_DAP_Vendor29                 0x9D
-#define ID_DAP_Vendor30                 0x9E
-#define ID_DAP_Vendor31                 0x9F
+#define ID_DAP_Vendor0                  0x80U
+#define ID_DAP_Vendor1                  0x81U
+#define ID_DAP_Vendor2                  0x82U
+#define ID_DAP_Vendor3                  0x83U
+#define ID_DAP_Vendor4                  0x84U
+#define ID_DAP_Vendor5                  0x85U
+#define ID_DAP_Vendor6                  0x86U
+#define ID_DAP_Vendor7                  0x87U
+#define ID_DAP_Vendor8                  0x88U
+#define ID_DAP_Vendor9                  0x89U
+#define ID_DAP_Vendor10                 0x8AU
+#define ID_DAP_Vendor11                 0x8BU
+#define ID_DAP_Vendor12                 0x8CU
+#define ID_DAP_Vendor13                 0x8DU
+#define ID_DAP_Vendor14                 0x8EU
+#define ID_DAP_Vendor15                 0x8FU
+#define ID_DAP_Vendor16                 0x90U
+#define ID_DAP_Vendor17                 0x91U
+#define ID_DAP_Vendor18                 0x92U
+#define ID_DAP_Vendor19                 0x93U
+#define ID_DAP_Vendor20                 0x94U
+#define ID_DAP_Vendor21                 0x95U
+#define ID_DAP_Vendor22                 0x96U
+#define ID_DAP_Vendor23                 0x97U
+#define ID_DAP_Vendor24                 0x98U
+#define ID_DAP_Vendor25                 0x99U
+#define ID_DAP_Vendor26                 0x9AU
+#define ID_DAP_Vendor27                 0x9BU
+#define ID_DAP_Vendor28                 0x9CU
+#define ID_DAP_Vendor29                 0x9DU
+#define ID_DAP_Vendor30                 0x9EU
+#define ID_DAP_Vendor31                 0x9FU
 
-#define ID_DAP_Invalid                  0xFF
+#define ID_DAP_Invalid                  0xFFU
 
 // DAP Status Code
-#define DAP_OK                          0
-#define DAP_ERROR                       0xFF
+#define DAP_OK                          0U
+#define DAP_ERROR                       0xFFU
 
 // DAP ID
-#define DAP_ID_VENDOR                   1
-#define DAP_ID_PRODUCT                  2
-#define DAP_ID_SER_NUM                  3
-#define DAP_ID_FW_VER                   4
-#define DAP_ID_DEVICE_VENDOR            5
-#define DAP_ID_DEVICE_NAME              6
-#define DAP_ID_CAPABILITIES             0xF0
-#define DAP_ID_PACKET_COUNT             0xFE
-#define DAP_ID_PACKET_SIZE              0xFF
+#define DAP_ID_VENDOR                   1U
+#define DAP_ID_PRODUCT                  2U
+#define DAP_ID_SER_NUM                  3U
+#define DAP_ID_FW_VER                   4U
+#define DAP_ID_DEVICE_VENDOR            5U
+#define DAP_ID_DEVICE_NAME              6U
+#define DAP_ID_CAPABILITIES             0xF0U
+#define DAP_ID_PACKET_COUNT             0xFEU
+#define DAP_ID_PACKET_SIZE              0xFFU
 
 // DAP Host Status
-#define DAP_DEBUGGER_CONNECTED          0
-#define DAP_TARGET_RUNNING              1
+#define DAP_DEBUGGER_CONNECTED          0U
+#define DAP_TARGET_RUNNING              1U
 
 // DAP Port
-#define DAP_PORT_AUTODETECT             0       // Autodetect Port
-#define DAP_PORT_DISABLED               0       // Port Disabled (I/O pins in High-Z)
-#define DAP_PORT_SWD                    1       // SWD Port (SWCLK, SWDIO) + nRESET
-#define DAP_PORT_JTAG                   2       // JTAG Port (TCK, TMS, TDI, TDO, nTRST) + nRESET
+#define DAP_PORT_AUTODETECT             0U      // Autodetect Port
+#define DAP_PORT_DISABLED               0U      // Port Disabled (I/O pins in High-Z)
+#define DAP_PORT_SWD                    1U      // SWD Port (SWCLK, SWDIO) + nRESET
+#define DAP_PORT_JTAG                   2U      // JTAG Port (TCK, TMS, TDI, TDO, nTRST) + nRESET
 
 // DAP SWJ Pins
 #define DAP_SWJ_SWCLK_TCK               0       // SWCLK/TCK
@@ -108,41 +108,41 @@
 #define DAP_SWJ_nRESET                  7       // nRESET
 
 // DAP Transfer Request
-#define DAP_TRANSFER_APnDP              (1<<0)
-#define DAP_TRANSFER_RnW                (1<<1)
-#define DAP_TRANSFER_A2                 (1<<2)
-#define DAP_TRANSFER_A3                 (1<<3)
-#define DAP_TRANSFER_MATCH_VALUE        (1<<4)
-#define DAP_TRANSFER_MATCH_MASK         (1<<5)
+#define DAP_TRANSFER_APnDP              (1U<<0)
+#define DAP_TRANSFER_RnW                (1U<<1)
+#define DAP_TRANSFER_A2                 (1U<<2)
+#define DAP_TRANSFER_A3                 (1U<<3)
+#define DAP_TRANSFER_MATCH_VALUE        (1U<<4)
+#define DAP_TRANSFER_MATCH_MASK         (1U<<5)
 
 // DAP Transfer Response
-#define DAP_TRANSFER_OK                 (1<<0)
-#define DAP_TRANSFER_WAIT               (1<<1)
-#define DAP_TRANSFER_FAULT              (1<<2)
-#define DAP_TRANSFER_ERROR              (1<<3)
-#define DAP_TRANSFER_MISMATCH           (1<<4)
+#define DAP_TRANSFER_OK                 (1U<<0)
+#define DAP_TRANSFER_WAIT               (1U<<1)
+#define DAP_TRANSFER_FAULT              (1U<<2)
+#define DAP_TRANSFER_ERROR              (1U<<3)
+#define DAP_TRANSFER_MISMATCH           (1U<<4)
 
 
 // Debug Port Register Addresses
-#define DP_IDCODE                       0x00    // IDCODE Register (SW Read only)
-#define DP_ABORT                        0x00    // Abort Register (SW Write only)
-#define DP_CTRL_STAT                    0x04    // Control & Status
-#define DP_WCR                          0x04    // Wire Control Register (SW Only)
-#define DP_SELECT                       0x08    // Select Register (JTAG R/W & SW W)
-#define DP_RESEND                       0x08    // Resend (SW Read Only)
-#define DP_RDBUFF                       0x0C    // Read Buffer (Read Only)
+#define DP_IDCODE                       0x00U   // IDCODE Register (SW Read only)
+#define DP_ABORT                        0x00U   // Abort Register (SW Write only)
+#define DP_CTRL_STAT                    0x04U   // Control & Status
+#define DP_WCR                          0x04U   // Wire Control Register (SW Only)
+#define DP_SELECT                       0x08U   // Select Register (JTAG R/W & SW W)
+#define DP_RESEND                       0x08U   // Resend (SW Read Only)
+#define DP_RDBUFF                       0x0CU   // Read Buffer (Read Only)
 
 // JTAG IR Codes
-#define JTAG_ABORT                      0x08
-#define JTAG_DPACC                      0x0A
-#define JTAG_APACC                      0x0B
-#define JTAG_IDCODE                     0x0E
-#define JTAG_BYPASS                     0x0F
+#define JTAG_ABORT                      0x08U
+#define JTAG_DPACC                      0x0AU
+#define JTAG_APACC                      0x0BU
+#define JTAG_IDCODE                     0x0EU
+#define JTAG_BYPASS                     0x0FU
 
 // JTAG Sequence Info
-#define JTAG_SEQUENCE_TCK               0x3F    // TCK count
-#define JTAG_SEQUENCE_TMS               0x40    // TMS value
-#define JTAG_SEQUENCE_TDO               0x80    // TDO capture
+#define JTAG_SEQUENCE_TCK               0x3FU   // TCK count
+#define JTAG_SEQUENCE_TMS               0x40U   // TMS value
+#define JTAG_SEQUENCE_TDO               0x80U   // TDO capture
 
 
 #include <stddef.h>
@@ -183,8 +183,8 @@ extern volatile uint8_t    DAP_TransferAbort;   // Transfer Abort Flag
 
 
 // Functions
-extern void     SWJ_Sequence    (uint32_t count, uint8_t *data);
-extern void     JTAG_Sequence   (uint32_t info,  uint8_t *tdi, uint8_t *tdo);
+extern void     SWJ_Sequence    (uint32_t count, const uint8_t *data);
+extern void     JTAG_Sequence   (uint32_t info,  const uint8_t *tdi, uint8_t *tdo);
 extern void     JTAG_IR         (uint32_t ir);
 extern uint32_t JTAG_ReadIDCode (void);
 extern void     JTAG_WriteAbort (uint32_t data);
@@ -193,9 +193,9 @@ extern uint8_t  SWD_Transfer    (uint32_t request, uint32_t *data);
 
 extern void     Delayms         (uint32_t delay);
 
-extern uint32_t DAP_ProcessVendorCommand (uint8_t *request, uint8_t *response);
+extern uint32_t DAP_ProcessVendorCommand (const uint8_t *request, uint8_t *response);
+extern uint32_t DAP_ProcessCommand (const uint8_t *request, uint8_t *response);
 
-extern uint32_t DAP_ProcessCommand (uint8_t *request, uint8_t *response);
 extern void     DAP_Setup (void);
 
 #ifndef __forceinline
@@ -204,10 +204,10 @@ extern void     DAP_Setup (void);
 
 // Configurable delay for clock generation
 #ifndef DELAY_SLOW_CYCLES
-#define DELAY_SLOW_CYCLES       3       // Number of cycles for one iteration
+#define DELAY_SLOW_CYCLES       3U      // Number of cycles for one iteration
 #endif
 static inline __forceinline void PIN_DELAY_SLOW (uint32_t delay) {
-  int32_t count;
+  uint32_t count;
 
   count = delay;
   while (--count);
@@ -215,16 +215,16 @@ static inline __forceinline void PIN_DELAY_SLOW (uint32_t delay) {
 
 // Fixed delay for fast clock generation
 #ifndef DELAY_FAST_CYCLES
-#define DELAY_FAST_CYCLES       0       // Number of cycles: 0..3
+#define DELAY_FAST_CYCLES       0U      // Number of cycles: 0..3
 #endif
 static inline __forceinline void PIN_DELAY_FAST (void) {
-#if (DELAY_FAST_CYCLES >= 1)
+#if (DELAY_FAST_CYCLES >= 1U)
   __nop();
 #endif
-#if (DELAY_FAST_CYCLES >= 2)
+#if (DELAY_FAST_CYCLES >= 2U)
   __nop();
 #endif
-#if (DELAY_FAST_CYCLES >= 3)
+#if (DELAY_FAST_CYCLES >= 3U)
   __nop();
 #endif
 }

--- a/src/DAP/JTAG_DP.c
+++ b/src/DAP/JTAG_DP.c
@@ -64,14 +64,14 @@
 //   tdi:    pointer to TDI generated data
 //   tdo:    pointer to TDO captured data
 //   return: none
-void JTAG_Sequence (uint32_t info, uint8_t *tdi, uint8_t *tdo) {
+void JTAG_Sequence (uint32_t info, const uint8_t *tdi, uint8_t *tdo) {
   uint32_t i_val;
   uint32_t o_val;
   uint32_t bit;
   uint32_t n, k;
 
   n = info & JTAG_SEQUENCE_TCK;
-  if (n == 0) n = 64;
+  if (n == 0U) { n = 64U; }
 
   if (info & JTAG_SEQUENCE_TMS) {
     PIN_TMS_SET();
@@ -81,8 +81,8 @@ void JTAG_Sequence (uint32_t info, uint8_t *tdi, uint8_t *tdo) {
 
   while (n) {
     i_val = *tdi++;
-    o_val = 0;
-    for (k = 8; k && n; k--, n--) {
+    o_val = 0U;
+    for (k = 8U; k && n; k--, n--) {
       JTAG_CYCLE_TDIO(i_val, bit);
       i_val >>= 1;
       o_val >>= 1;
@@ -90,7 +90,7 @@ void JTAG_Sequence (uint32_t info, uint8_t *tdi, uint8_t *tdo) {
     }
     o_val >>= k;
     if (info & JTAG_SEQUENCE_TDO) {
-      *tdo++ = o_val;
+      *tdo++ = (uint8_t)o_val;
     }
   }
 }
@@ -110,18 +110,18 @@ void JTAG_IR_##speed (uint32_t ir) {                                            
   JTAG_CYCLE_TCK();                         /* Capture-IR */                    \
   JTAG_CYCLE_TCK();                         /* Shift-IR */                      \
                                                                                 \
-  PIN_TDI_OUT(1);                                                               \
+  PIN_TDI_OUT(1U);                                                              \
   for (n = DAP_Data.jtag_dev.ir_before[DAP_Data.jtag_dev.index]; n; n--) {      \
     JTAG_CYCLE_TCK();                       /* Bypass before data */            \
   }                                                                             \
-  for (n = DAP_Data.jtag_dev.ir_length[DAP_Data.jtag_dev.index] - 1; n; n--) {  \
+  for (n = DAP_Data.jtag_dev.ir_length[DAP_Data.jtag_dev.index] - 1U; n; n--) { \
     JTAG_CYCLE_TDI(ir);                     /* Set IR bits (except last) */     \
     ir >>= 1;                                                                   \
   }                                                                             \
   n = DAP_Data.jtag_dev.ir_after[DAP_Data.jtag_dev.index];                      \
   if (n) {                                                                      \
     JTAG_CYCLE_TDI(ir);                     /* Set last IR bit */               \
-    PIN_TDI_OUT(1);                                                             \
+    PIN_TDI_OUT(1U);                                                            \
     for (--n; n; n--) {                                                         \
       JTAG_CYCLE_TCK();                     /* Bypass after data */             \
     }                                                                           \
@@ -135,7 +135,7 @@ void JTAG_IR_##speed (uint32_t ir) {                                            
   JTAG_CYCLE_TCK();                         /* Update-IR */                     \
   PIN_TMS_CLR();                                                                \
   JTAG_CYCLE_TCK();                         /* Idle */                          \
-  PIN_TDI_OUT(1);                                                               \
+  PIN_TDI_OUT(1U);                                                             \
 }
 
 
@@ -176,13 +176,13 @@ uint8_t JTAG_Transfer##speed (uint32_t request, uint32_t *data) {               
                                                                                 \
   if (request & DAP_TRANSFER_RnW) {                                             \
     /* Read Transfer */                                                         \
-    val = 0;                                                                    \
-    for (n = 31; n; n--) {                                                      \
+    val = 0U;                                                                   \
+    for (n = 31U; n; n--) {                                                     \
       JTAG_CYCLE_TDO(bit);                  /* Get D0..D30 */                   \
       val  |= bit << 31;                                                        \
       val >>= 1;                                                                \
     }                                                                           \
-    n = DAP_Data.jtag_dev.count - DAP_Data.jtag_dev.index - 1;                  \
+    n = DAP_Data.jtag_dev.count - DAP_Data.jtag_dev.index - 1U;                 \
     if (n) {                                                                    \
       JTAG_CYCLE_TDO(bit);                  /* Get D31 */                       \
       for (--n; n; n--) {                                                       \
@@ -195,15 +195,15 @@ uint8_t JTAG_Transfer##speed (uint32_t request, uint32_t *data) {               
       JTAG_CYCLE_TDO(bit);                  /* Get D31 & Exit1-DR */            \
     }                                                                           \
     val |= bit << 31;                                                           \
-    if (data) *data = val;                                                      \
+    if (data) { *data = val; }                                                  \
   } else {                                                                      \
     /* Write Transfer */                                                        \
     val = *data;                                                                \
-    for (n = 31; n; n--) {                                                      \
+    for (n = 31U; n; n--) {                                                     \
       JTAG_CYCLE_TDI(val);                  /* Set D0..D30 */                   \
       val >>= 1;                                                                \
     }                                                                           \
-    n = DAP_Data.jtag_dev.count - DAP_Data.jtag_dev.index - 1;                  \
+    n = DAP_Data.jtag_dev.count - DAP_Data.jtag_dev.index - 1u;                 \
     if (n) {                                                                    \
       JTAG_CYCLE_TDI(val);                  /* Set D31 */                       \
       for (--n; n; n--) {                                                       \
@@ -221,7 +221,7 @@ exit:                                                                           
   JTAG_CYCLE_TCK();                         /* Update-DR */                     \
   PIN_TMS_CLR();                                                                \
   JTAG_CYCLE_TCK();                         /* Idle */                          \
-  PIN_TDI_OUT(1);                                                               \
+  PIN_TDI_OUT(1U);                                                              \
                                                                                 \
   /* Idle cycles */                                                             \
   n = DAP_Data.transfer.idle_cycles;                                            \
@@ -229,7 +229,7 @@ exit:                                                                           
     JTAG_CYCLE_TCK();                       /* Idle */                          \
   }                                                                             \
                                                                                 \
-  return (ack);                                                                 \
+  return ((uint8_t)ack);                                                        \
 }
 
 
@@ -261,8 +261,8 @@ uint32_t JTAG_ReadIDCode (void) {
     JTAG_CYCLE_TCK();                       /* Bypass before data */
   }
 
-  val = 0;
-  for (n = 31; n; n--) {
+  val = 0U;
+  for (n = 31U; n; n--) {
     JTAG_CYCLE_TDO(bit);                    /* Get D0..D30 */
     val  |= bit << 31;
     val >>= 1;
@@ -295,16 +295,16 @@ void JTAG_WriteAbort (uint32_t data) {
     JTAG_CYCLE_TCK();                       /* Bypass before data */
   }
 
-  PIN_TDI_OUT(0);
+  PIN_TDI_OUT(0U);
   JTAG_CYCLE_TCK();                         /* Set RnW=0 (Write) */
   JTAG_CYCLE_TCK();                         /* Set A2=0 */
   JTAG_CYCLE_TCK();                         /* Set A3=0 */
 
-  for (n = 31; n; n--) {
+  for (n = 31U; n; n--) {
     JTAG_CYCLE_TDI(data);                   /* Set D0..D30 */
     data >>= 1;
   }
-  n = DAP_Data.jtag_dev.count - DAP_Data.jtag_dev.index - 1;
+  n = DAP_Data.jtag_dev.count - DAP_Data.jtag_dev.index - 1u;
   if (n) {
     JTAG_CYCLE_TDI(data);                   /* Set D31 */
     for (--n; n; n--) {
@@ -320,7 +320,7 @@ void JTAG_WriteAbort (uint32_t data) {
   JTAG_CYCLE_TCK();                         /* Update-DR */
   PIN_TMS_CLR();
   JTAG_CYCLE_TCK();                         /* Idle */
-  PIN_TDI_OUT(1);
+  PIN_TDI_OUT(1U);
 }
 
 

--- a/src/DAP/SW_DP.c
+++ b/src/DAP/SW_DP.c
@@ -51,18 +51,18 @@
 //   data:   pointer to sequence bit data
 //   return: none
 #if ((DAP_SWD != 0) || (DAP_JTAG != 0))
-void SWJ_Sequence (uint32_t count, uint8_t *data) {
+void SWJ_Sequence (uint32_t count, const uint8_t *data) {
   uint32_t val;
   uint32_t n;
 
-  val = 0;
-  n = 0;
+  val = 0U;
+  n = 0U;
   while (count--) {
-    if (n == 0) {
+    if (n == 0U) {
       val = *data++;
-      n = 8;
+      n = 8U;
     }
-    if (val & 1) {
+    if (val & 1U) {
       PIN_SWDIO_TMS_SET();
     } else {
       PIN_SWDIO_TMS_CLR();
@@ -92,8 +92,8 @@ static uint8_t SWD_Transfer##speed (uint32_t request, uint32_t *data) {         
   uint32_t n;                                                                   \
                                                                                 \
   /* Packet Request */                                                          \
-  parity = 0;                                                                   \
-  SW_WRITE_BIT(1);                      /* Start Bit */                         \
+  parity = 0U;                                                                  \
+  SW_WRITE_BIT(1U);                     /* Start Bit */                         \
   bit = request >> 0;                                                           \
   SW_WRITE_BIT(bit);                    /* APnDP Bit */                         \
   parity += bit;                                                                \
@@ -107,8 +107,8 @@ static uint8_t SWD_Transfer##speed (uint32_t request, uint32_t *data) {         
   SW_WRITE_BIT(bit);                    /* A3 Bit */                            \
   parity += bit;                                                                \
   SW_WRITE_BIT(parity);                 /* Parity Bit */                        \
-  SW_WRITE_BIT(0);                      /* Stop Bit */                          \
-  SW_WRITE_BIT(1);                      /* Park Bit */                          \
+  SW_WRITE_BIT(0U);                     /* Stop Bit */                          \
+  SW_WRITE_BIT(1U);                     /* Park Bit */                          \
                                                                                 \
   /* Turnaround */                                                              \
   PIN_SWDIO_OUT_DISABLE();                                                      \
@@ -128,19 +128,19 @@ static uint8_t SWD_Transfer##speed (uint32_t request, uint32_t *data) {         
     /* Data transfer */                                                         \
     if (request & DAP_TRANSFER_RnW) {                                           \
       /* Read data */                                                           \
-      val = 0;                                                                  \
-      parity = 0;                                                               \
-      for (n = 32; n; n--) {                                                    \
+      val = 0U;                                                                 \
+      parity = 0U;                                                              \
+      for (n = 32U; n; n--) {                                                   \
         SW_READ_BIT(bit);               /* Read RDATA[0:31] */                  \
         parity += bit;                                                          \
         val >>= 1;                                                              \
         val  |= bit << 31;                                                      \
       }                                                                         \
       SW_READ_BIT(bit);                 /* Read Parity */                       \
-      if ((parity ^ bit) & 1) {                                                 \
+      if ((parity ^ bit) & 1U) {                                                \
         ack = DAP_TRANSFER_ERROR;                                               \
       }                                                                         \
-      if (data) *data = val;                                                    \
+      if (data) { *data = val; }                                                \
       /* Turnaround */                                                          \
       for (n = DAP_Data.swd_conf.turnaround; n; n--) {                          \
         SW_CLOCK_CYCLE();                                                       \
@@ -154,8 +154,8 @@ static uint8_t SWD_Transfer##speed (uint32_t request, uint32_t *data) {         
       PIN_SWDIO_OUT_ENABLE();                                                   \
       /* Write data */                                                          \
       val = *data;                                                              \
-      parity = 0;                                                               \
-      for (n = 32; n; n--) {                                                    \
+      parity = 0U;                                                              \
+      for (n = 32U; n; n--) {                                                   \
         SW_WRITE_BIT(val);              /* Write WDATA[0:31] */                 \
         parity += val;                                                          \
         val >>= 1;                                                              \
@@ -165,19 +165,19 @@ static uint8_t SWD_Transfer##speed (uint32_t request, uint32_t *data) {         
     /* Idle cycles */                                                           \
     n = DAP_Data.transfer.idle_cycles;                                          \
     if (n) {                                                                    \
-      PIN_SWDIO_OUT(0);                                                         \
+      PIN_SWDIO_OUT(0U);                                                        \
       for (; n; n--) {                                                          \
         SW_CLOCK_CYCLE();                                                       \
       }                                                                         \
     }                                                                           \
-    PIN_SWDIO_OUT(1);                                                           \
-    return (ack);                                                               \
+    PIN_SWDIO_OUT(1U);                                                          \
+    return ((uint8_t)ack);                                                      \
   }                                                                             \
                                                                                 \
   if ((ack == DAP_TRANSFER_WAIT) || (ack == DAP_TRANSFER_FAULT)) {              \
     /* WAIT or FAULT response */                                                \
-    if (DAP_Data.swd_conf.data_phase && ((request & DAP_TRANSFER_RnW) != 0)) {  \
-      for (n = 32+1; n; n--) {                                                  \
+    if (DAP_Data.swd_conf.data_phase && ((request & DAP_TRANSFER_RnW) != 0U)) { \
+      for (n = 32U+1U; n; n--) {                                                \
         SW_CLOCK_CYCLE();               /* Dummy Read RDATA[0:31] + Parity */   \
       }                                                                         \
     }                                                                           \
@@ -186,22 +186,22 @@ static uint8_t SWD_Transfer##speed (uint32_t request, uint32_t *data) {         
       SW_CLOCK_CYCLE();                                                         \
     }                                                                           \
     PIN_SWDIO_OUT_ENABLE();                                                     \
-    if (DAP_Data.swd_conf.data_phase && ((request & DAP_TRANSFER_RnW) == 0)) {  \
-      PIN_SWDIO_OUT(0);                                                         \
-      for (n = 32+1; n; n--) {                                                  \
+    if (DAP_Data.swd_conf.data_phase && ((request & DAP_TRANSFER_RnW) == 0U)) { \
+      PIN_SWDIO_OUT(0U);                                                        \
+      for (n = 32U+1U; n; n--) {                                                \
         SW_CLOCK_CYCLE();               /* Dummy Write WDATA[0:31] + Parity */  \
       }                                                                         \
     }                                                                           \
-    PIN_SWDIO_OUT(1);                                                           \
-    return (ack);                                                               \
+    PIN_SWDIO_OUT(1U);                                                          \
+    return ((uint8_t)ack);                                                      \
   }                                                                             \
                                                                                 \
   /* Protocol error */                                                          \
-  for (n = DAP_Data.swd_conf.turnaround + 32 + 1; n; n--) {                     \
+  for (n = DAP_Data.swd_conf.turnaround + 32U + 1U; n; n--) {                   \
     SW_CLOCK_CYCLE();                   /* Back off data phase */               \
   }                                                                             \
-  PIN_SWDIO_OUT(1);                                                             \
-  return (ack);                                                                 \
+  PIN_SWDIO_OUT(1U);                                                            \
+  return ((uint8_t)ack);                                                        \
 }
 
 

--- a/src/DAP/app.c
+++ b/src/DAP/app.c
@@ -54,7 +54,7 @@ static void on_send_report(uint8_t* data, uint16_t* len) {
     }
 }
 
-uint32_t DAP_ProcessVendorCommand(uint8_t* request, uint8_t* response) {
+uint32_t DAP_ProcessVendorCommand(const uint8_t* request, uint8_t* response) {
     if (request[0] == ID_DAP_Vendor31) {
         if (request[1] == 'D' && request[2] == 'F' && request[3] == 'U') {
             response[0] = request[0];

--- a/src/DAP/app.c
+++ b/src/DAP/app.c
@@ -65,16 +65,16 @@ uint32_t DAP_ProcessVendorCommand(const uint8_t* request, uint8_t* response) {
             } else {
                 response[1] = DAP_ERROR;
             }
-            return 2;
+            return ((4U << 16) | 2U);
         } else {
             response[0] = request[0];
             response[1] = DAP_ERROR;
-            return 2;
+            return ((4U << 16) | 2U);
         }
     }
 
     response[0] = ID_DAP_Invalid;
-    return 1;
+    return ((1U << 16) | 1U);
 }
 
 static void DAP_app_reset(void) {
@@ -87,7 +87,7 @@ bool DAP_app_update(void) {
 
     if (process_head != inbox_tail) {
         memset(response_buffers[process_head], 0, DAP_PACKET_SIZE);
-        DAP_ProcessCommand(request_buffers[process_head],
+        DAP_ExecuteCommand(request_buffers[process_head],
                            response_buffers[process_head]);
         process_head = (process_head + 1) % DAP_PACKET_QUEUE_SIZE;
         active = true;

--- a/src/stm32f042/DAP/CMSIS_DAP_hal.h
+++ b/src/stm32f042/DAP/CMSIS_DAP_hal.h
@@ -49,6 +49,23 @@
 
 #include <libopencm3/stm32/gpio.h>
 #include "DAP/CMSIS_DAP_config.h"
+#include "tick.h"
+#include <libopencm3/cm3/systick.h>
+#include <libopencmsis/core_cm3.h>
+
+
+/*
+ * TIMESTAMP SUPPORT
+ */
+
+// Get current timestamp value, in micro-seconds:
+// Use SYSTICK value and timer ticks, assume 1ms counter.
+static __inline uint32_t TIMESTAMP_GET (void) {
+  uint32_t reload = STK_RVR;
+  uint32_t current = STK_CVR;
+  uint32_t tick = get_ticks();
+  return tick * 1000U + (reload - current) / (CPU_CLOCK / TIMESTAMP_CLOCK);
+}
 
 /*
 SWD functionality

--- a/src/stm32f042/brain3.3/DAP/CMSIS_DAP_config.h
+++ b/src/stm32f042/brain3.3/DAP/CMSIS_DAP_config.h
@@ -1,61 +1,46 @@
 /*
- * Copyright (c) 2015, Devan Lai
+ * Copyright (c) 2013-2017 ARM Limited. All rights reserved.
  *
- * Permission to use, copy, modify, and/or distribute this software
- * for any purpose with or without fee is hereby granted, provided
- * that the above copyright notice and this permission notice
- * appear in all copies.
+ * SPDX-License-Identifier: Apache-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
- * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
- * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
- * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
- * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- */
-
-/*
-    Portions of this file are derived from:
-
-    Dapper Mime - an open-source CMSIS-DAP implementation
-    HAL for STM32F0xx2
-    this file is used by the mbed CMSIS-DAP routines
-
-    Copyright (C) 2014 Peter Lawrence
-
-    Permission is hereby granted, free of charge, to any person obtaining a 
-    copy of this software and associated documentation files (the "Software"), 
-    to deal in the Software without restriction, including without limitation 
-    the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-    and/or sell copies of the Software, and to permit persons to whom the 
-    Software is furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in 
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-    DEALINGS IN THE SOFTWARE.
-*/
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        1. December 2017
+ * $Revision:    V2.0.0
+ *
+ * Project:      CMSIS-DAP Configuration
+ * Title:        DAP_config.h CMSIS-DAP Configuration File (Template)
+ *
+ *---------------------------------------------------------------------------*/
 
 #ifndef __DAP_CONFIG_H__
 #define __DAP_CONFIG_H__
+
 
 //**************************************************************************************************
 /**
 \defgroup DAP_Config_Debug_gr CMSIS-DAP Debug Unit Information
 \ingroup DAP_ConfigIO_gr
 @{
-Provides definitions about:
+Provides definitions about the hardware and configuration of the Debug Unit.
+
+This information includes:
  - Definition of Cortex-M processor parameters used in CMSIS-DAP Debug Unit.
+ - Debug Unit Identification strings (Vendor, Product, Serial Number).
  - Debug Unit communication packet size.
- - Debug Access Port communication mode (JTAG or SWD).
+ - Debug Access Port supported modes and settings (JTAG/SWD and SWO).
  - Optional information about a connected Target Device (for Evaluation Boards).
 */
 
@@ -65,19 +50,19 @@ Provides definitions about:
 
 /// Processor Clock of the Cortex-M MCU used in the Debug Unit.
 /// This value is used to calculate the SWD/JTAG clock speed.
-#define CPU_CLOCK               48000000        ///< Specifies the CPU Clock in Hz
+#define CPU_CLOCK               48000000U      ///< Specifies the CPU Clock in Hz.
 
 /// Number of processor cycles for I/O Port write operations.
 /// This value is used to calculate the SWD/JTAG clock speed that is generated with I/O
 /// Port write operations in the Debug Unit by a Cortex-M MCU. Most Cortex-M processors
-/// requrie 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
+/// require 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
 /// a Cortex-M0+ processor with high-speed peripheral I/O only 1 processor cycle might be
 /// required.
-#define IO_PORT_WRITE_CYCLES    2               ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0
+#define IO_PORT_WRITE_CYCLES    2U              ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0.
 
 /// Indicate that Serial Wire Debug (SWD) communication mode is available at the Debug Access Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
-#define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available
+#define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available.
 
 /// Indicate that JTAG communication mode is available at the Debug Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
@@ -89,29 +74,50 @@ Provides definitions about:
 
 /// Configure maximum number of JTAG devices on the scan chain connected to the Debug Access Port.
 /// This setting impacts the RAM requirements of the Debug Unit. Valid range is 1 .. 255.
-#define DAP_JTAG_DEV_CNT        8               ///< Maximum number of JTAG devices on scan chain
+#define DAP_JTAG_DEV_CNT        8U              ///< Maximum number of JTAG devices on scan chain.
 
 /// Default communication mode on the Debug Access Port.
 /// Used for the command \ref DAP_Connect when Port Default mode is selected.
-#define DAP_DEFAULT_PORT        1               ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
+#define DAP_DEFAULT_PORT        1U              ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
 
 /// Default communication speed on the Debug Access Port for SWD and JTAG mode.
 /// Used to initialize the default SWD/JTAG clock frequency.
 /// The command \ref DAP_SWJ_Clock can be used to overwrite this default setting.
-#define DAP_DEFAULT_SWJ_CLOCK   10000000         ///< Default SWD/JTAG clock frequency in Hz.
+#define DAP_DEFAULT_SWJ_CLOCK   10000000U        ///< Default SWD/JTAG clock frequency in Hz.
 
 /// Maximum Package Size for Command and Response data.
-/// This configuration settings is used to optimized the communication performance with the
-/// debugger and depends on the USB peripheral. Change setting to 1024 for High-Speed USB.
-#define DAP_PACKET_SIZE         64              ///< USB: 64 = Full-Speed, 1024 = High-Speed.
+/// This configuration settings is used to optimize the communication performance with the
+/// debugger and depends on the USB peripheral. Typical vales are 64 for Full-speed USB HID or WinUSB,
+/// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
+#define DAP_PACKET_SIZE         64U             ///< Specifies Packet Size in bytes.
 
 /// Maximum Package Buffers for Command and Response data.
-/// This configuration settings is used to optimized the communication performance with the
+/// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. For devices with limited RAM or USB buffer the
-/// setting can be reduced (valid range is 1 .. 255). Change setting to 4 for High-Speed USB.
-#define DAP_PACKET_COUNT        12              ///< Buffers: 64 = Full-Speed, 4 = High-Speed.
+/// setting can be reduced (valid range is 1 .. 255).
+#define DAP_PACKET_COUNT        12U            ///< Specifies number of packets buffered.
 
 #define DAP_PACKET_QUEUE_SIZE (DAP_PACKET_COUNT+8)
+
+/// Indicate that UART Serial Wire Output (SWO) trace is available.
+/// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
+#define SWO_UART                0               ///< SWO UART:  1 = available, 0 = not available.
+
+/// Maximum SWO UART Baudrate.
+#define SWO_UART_MAX_BAUDRATE   10000000U       ///< SWO UART Maximum Baudrate in Hz.
+
+/// Indicate that Manchester Serial Wire Output (SWO) trace is available.
+/// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
+#define SWO_MANCHESTER          0               ///< SWO Manchester:  1 = available, 0 = not available.
+
+/// SWO Trace Buffer Size.
+#define SWO_BUFFER_SIZE         4096U           ///< SWO Trace Buffer Size in bytes (must be 2^n).
+
+/// SWO Streaming Trace.
+#define SWO_STREAM              0               ///< SWO Streaming Trace: 1 = available, 0 = not available.
+
+/// Clock frequency of the Test Domain Timer. Timer value is returned with \ref TIMESTAMP_GET.
+#define TIMESTAMP_CLOCK         48000000U       ///< Timestamp clock in Hz (0 = timestamps not supported).
 
 /// Debug Unit is connected to fixed Target Device.
 /// The Debug Unit may be part of an evaluation board and always connected to a fixed
@@ -123,6 +129,33 @@ Provides definitions about:
 #define TARGET_DEVICE_VENDOR    "NXP"           ///< String indicating the Silicon Vendor
 #define TARGET_DEVICE_NAME      "LPC1549"       ///< String indicating the Target Device
 #endif
+
+/** Get Vendor ID string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetVendorString (char *str) {
+  (void)str;
+  return (0U);
+}
+
+/** Get Product ID string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetProductString (char *str) {
+  (void)str;
+  return (0U);
+}
+
+/** Get Serial Number string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetSerNumString (char *str) {
+  (void)str;
+  return (0U);
+}
 
 ///@}
 
@@ -142,4 +175,4 @@ Provides definitions about:
 
 #define SWDIO_GPIO_PIN_NUM      0
 
-#endif
+#endif /* __DAP_CONFIG_H__ */

--- a/src/stm32f042/dap42/DAP/CMSIS_DAP_config.h
+++ b/src/stm32f042/dap42/DAP/CMSIS_DAP_config.h
@@ -1,61 +1,46 @@
 /*
- * Copyright (c) 2015, Devan Lai
+ * Copyright (c) 2013-2017 ARM Limited. All rights reserved.
  *
- * Permission to use, copy, modify, and/or distribute this software
- * for any purpose with or without fee is hereby granted, provided
- * that the above copyright notice and this permission notice
- * appear in all copies.
+ * SPDX-License-Identifier: Apache-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
- * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
- * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
- * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
- * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- */
-
-/*
-    Portions of this file are derived from:
-
-    Dapper Mime - an open-source CMSIS-DAP implementation
-    HAL for STM32F0xx2
-    this file is used by the mbed CMSIS-DAP routines
-
-    Copyright (C) 2014 Peter Lawrence
-
-    Permission is hereby granted, free of charge, to any person obtaining a 
-    copy of this software and associated documentation files (the "Software"), 
-    to deal in the Software without restriction, including without limitation 
-    the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-    and/or sell copies of the Software, and to permit persons to whom the 
-    Software is furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in 
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-    DEALINGS IN THE SOFTWARE.
-*/
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        1. December 2017
+ * $Revision:    V2.0.0
+ *
+ * Project:      CMSIS-DAP Configuration
+ * Title:        DAP_config.h CMSIS-DAP Configuration File (Template)
+ *
+ *---------------------------------------------------------------------------*/
 
 #ifndef __DAP_CONFIG_H__
 #define __DAP_CONFIG_H__
+
 
 //**************************************************************************************************
 /**
 \defgroup DAP_Config_Debug_gr CMSIS-DAP Debug Unit Information
 \ingroup DAP_ConfigIO_gr
 @{
-Provides definitions about:
+Provides definitions about the hardware and configuration of the Debug Unit.
+
+This information includes:
  - Definition of Cortex-M processor parameters used in CMSIS-DAP Debug Unit.
+ - Debug Unit Identification strings (Vendor, Product, Serial Number).
  - Debug Unit communication packet size.
- - Debug Access Port communication mode (JTAG or SWD).
+ - Debug Access Port supported modes and settings (JTAG/SWD and SWO).
  - Optional information about a connected Target Device (for Evaluation Boards).
 */
 
@@ -65,19 +50,19 @@ Provides definitions about:
 
 /// Processor Clock of the Cortex-M MCU used in the Debug Unit.
 /// This value is used to calculate the SWD/JTAG clock speed.
-#define CPU_CLOCK               48000000        ///< Specifies the CPU Clock in Hz
+#define CPU_CLOCK               48000000U      ///< Specifies the CPU Clock in Hz.
 
 /// Number of processor cycles for I/O Port write operations.
 /// This value is used to calculate the SWD/JTAG clock speed that is generated with I/O
 /// Port write operations in the Debug Unit by a Cortex-M MCU. Most Cortex-M processors
-/// requrie 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
+/// require 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
 /// a Cortex-M0+ processor with high-speed peripheral I/O only 1 processor cycle might be
 /// required.
-#define IO_PORT_WRITE_CYCLES    2               ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0
+#define IO_PORT_WRITE_CYCLES    2U              ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0.
 
 /// Indicate that Serial Wire Debug (SWD) communication mode is available at the Debug Access Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
-#define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available
+#define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available.
 
 /// Indicate that JTAG communication mode is available at the Debug Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
@@ -89,29 +74,50 @@ Provides definitions about:
 
 /// Configure maximum number of JTAG devices on the scan chain connected to the Debug Access Port.
 /// This setting impacts the RAM requirements of the Debug Unit. Valid range is 1 .. 255.
-#define DAP_JTAG_DEV_CNT        8               ///< Maximum number of JTAG devices on scan chain
+#define DAP_JTAG_DEV_CNT        8U              ///< Maximum number of JTAG devices on scan chain
 
 /// Default communication mode on the Debug Access Port.
 /// Used for the command \ref DAP_Connect when Port Default mode is selected.
-#define DAP_DEFAULT_PORT        1               ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
+#define DAP_DEFAULT_PORT        1U              ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
 
 /// Default communication speed on the Debug Access Port for SWD and JTAG mode.
 /// Used to initialize the default SWD/JTAG clock frequency.
 /// The command \ref DAP_SWJ_Clock can be used to overwrite this default setting.
-#define DAP_DEFAULT_SWJ_CLOCK   10000000         ///< Default SWD/JTAG clock frequency in Hz.
+#define DAP_DEFAULT_SWJ_CLOCK   10000000U        ///< Default SWD/JTAG clock frequency in Hz.
 
 /// Maximum Package Size for Command and Response data.
-/// This configuration settings is used to optimized the communication performance with the
-/// debugger and depends on the USB peripheral. Change setting to 1024 for High-Speed USB.
-#define DAP_PACKET_SIZE         64              ///< USB: 64 = Full-Speed, 1024 = High-Speed.
+/// This configuration settings is used to optimize the communication performance with the
+/// debugger and depends on the USB peripheral. Typical vales are 64 for Full-speed USB HID or WinUSB,
+/// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
+#define DAP_PACKET_SIZE         64U             ///< Specifies Packet Size in bytes.
 
 /// Maximum Package Buffers for Command and Response data.
-/// This configuration settings is used to optimized the communication performance with the
+/// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. For devices with limited RAM or USB buffer the
-/// setting can be reduced (valid range is 1 .. 255). Change setting to 4 for High-Speed USB.
-#define DAP_PACKET_COUNT        12              ///< Buffers: 64 = Full-Speed, 4 = High-Speed.
+/// setting can be reduced (valid range is 1 .. 255).
+#define DAP_PACKET_COUNT        12U            ///< Specifies number of packets buffered.
 
 #define DAP_PACKET_QUEUE_SIZE (DAP_PACKET_COUNT+8)
+
+/// Indicate that UART Serial Wire Output (SWO) trace is available.
+/// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
+#define SWO_UART                0               ///< SWO UART:  1 = available, 0 = not available.
+
+/// Maximum SWO UART Baudrate.
+#define SWO_UART_MAX_BAUDRATE   10000000U       ///< SWO UART Maximum Baudrate in Hz.
+
+/// Indicate that Manchester Serial Wire Output (SWO) trace is available.
+/// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
+#define SWO_MANCHESTER          0               ///< SWO Manchester:  1 = available, 0 = not available.
+
+/// SWO Trace Buffer Size.
+#define SWO_BUFFER_SIZE         4096U           ///< SWO Trace Buffer Size in bytes (must be 2^n).
+
+/// SWO Streaming Trace.
+#define SWO_STREAM              0               ///< SWO Streaming Trace: 1 = available, 0 = not available.
+
+/// Clock frequency of the Test Domain Timer. Timer value is returned with \ref TIMESTAMP_GET.
+#define TIMESTAMP_CLOCK         48000000U       ///< Timestamp clock in Hz (0 = timestamps not supported).
 
 /// Debug Unit is connected to fixed Target Device.
 /// The Debug Unit may be part of an evaluation board and always connected to a fixed
@@ -123,6 +129,33 @@ Provides definitions about:
 #define TARGET_DEVICE_VENDOR    ""              ///< String indicating the Silicon Vendor
 #define TARGET_DEVICE_NAME      ""              ///< String indicating the Target Device
 #endif
+
+/** Get Vendor ID string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetVendorString (char *str) {
+  (void)str;
+  return (0U);
+}
+
+/** Get Product ID string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetProductString (char *str) {
+  (void)str;
+  return (0U);
+}
+
+/** Get Serial Number string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetSerNumString (char *str) {
+  (void)str;
+  return (0U);
+}
 
 ///@}
 
@@ -142,4 +175,4 @@ Provides definitions about:
 
 #define SWDIO_GPIO_PIN_NUM      5
 
-#endif
+#endif /* __DAP_CONFIG_H__ */

--- a/src/stm32f042/dap42dc/DAP/CMSIS_DAP_config.h
+++ b/src/stm32f042/dap42dc/DAP/CMSIS_DAP_config.h
@@ -1,61 +1,46 @@
 /*
- * Copyright (c) 2015, Devan Lai
+ * Copyright (c) 2013-2017 ARM Limited. All rights reserved.
  *
- * Permission to use, copy, modify, and/or distribute this software
- * for any purpose with or without fee is hereby granted, provided
- * that the above copyright notice and this permission notice
- * appear in all copies.
+ * SPDX-License-Identifier: Apache-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
- * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
- * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
- * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
- * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- */
-
-/*
-    Portions of this file are derived from:
-
-    Dapper Mime - an open-source CMSIS-DAP implementation
-    HAL for STM32F0xx2
-    this file is used by the mbed CMSIS-DAP routines
-
-    Copyright (C) 2014 Peter Lawrence
-
-    Permission is hereby granted, free of charge, to any person obtaining a 
-    copy of this software and associated documentation files (the "Software"), 
-    to deal in the Software without restriction, including without limitation 
-    the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-    and/or sell copies of the Software, and to permit persons to whom the 
-    Software is furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in 
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-    DEALINGS IN THE SOFTWARE.
-*/
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        1. December 2017
+ * $Revision:    V2.0.0
+ *
+ * Project:      CMSIS-DAP Configuration
+ * Title:        DAP_config.h CMSIS-DAP Configuration File (Template)
+ *
+ *---------------------------------------------------------------------------*/
 
 #ifndef __DAP_CONFIG_H__
 #define __DAP_CONFIG_H__
+
 
 //**************************************************************************************************
 /**
 \defgroup DAP_Config_Debug_gr CMSIS-DAP Debug Unit Information
 \ingroup DAP_ConfigIO_gr
 @{
-Provides definitions about:
+Provides definitions about the hardware and configuration of the Debug Unit.
+
+This information includes:
  - Definition of Cortex-M processor parameters used in CMSIS-DAP Debug Unit.
+ - Debug Unit Identification strings (Vendor, Product, Serial Number).
  - Debug Unit communication packet size.
- - Debug Access Port communication mode (JTAG or SWD).
+ - Debug Access Port supported modes and settings (JTAG/SWD and SWO).
  - Optional information about a connected Target Device (for Evaluation Boards).
 */
 
@@ -65,19 +50,19 @@ Provides definitions about:
 
 /// Processor Clock of the Cortex-M MCU used in the Debug Unit.
 /// This value is used to calculate the SWD/JTAG clock speed.
-#define CPU_CLOCK               48000000        ///< Specifies the CPU Clock in Hz
+#define CPU_CLOCK               48000000U      ///< Specifies the CPU Clock in Hz.
 
 /// Number of processor cycles for I/O Port write operations.
 /// This value is used to calculate the SWD/JTAG clock speed that is generated with I/O
 /// Port write operations in the Debug Unit by a Cortex-M MCU. Most Cortex-M processors
-/// requrie 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
+/// require 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
 /// a Cortex-M0+ processor with high-speed peripheral I/O only 1 processor cycle might be
 /// required.
-#define IO_PORT_WRITE_CYCLES    2               ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0
+#define IO_PORT_WRITE_CYCLES    2U              ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0.
 
 /// Indicate that Serial Wire Debug (SWD) communication mode is available at the Debug Access Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
-#define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available
+#define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available.
 
 /// Indicate that JTAG communication mode is available at the Debug Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
@@ -89,29 +74,50 @@ Provides definitions about:
 
 /// Configure maximum number of JTAG devices on the scan chain connected to the Debug Access Port.
 /// This setting impacts the RAM requirements of the Debug Unit. Valid range is 1 .. 255.
-#define DAP_JTAG_DEV_CNT        8               ///< Maximum number of JTAG devices on scan chain
+#define DAP_JTAG_DEV_CNT        8U              ///< Maximum number of JTAG devices on scan chain
 
 /// Default communication mode on the Debug Access Port.
 /// Used for the command \ref DAP_Connect when Port Default mode is selected.
-#define DAP_DEFAULT_PORT        1               ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
+#define DAP_DEFAULT_PORT        1U              ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
 
 /// Default communication speed on the Debug Access Port for SWD and JTAG mode.
 /// Used to initialize the default SWD/JTAG clock frequency.
 /// The command \ref DAP_SWJ_Clock can be used to overwrite this default setting.
-#define DAP_DEFAULT_SWJ_CLOCK   10000000         ///< Default SWD/JTAG clock frequency in Hz.
+#define DAP_DEFAULT_SWJ_CLOCK   10000000U        ///< Default SWD/JTAG clock frequency in Hz.
 
 /// Maximum Package Size for Command and Response data.
-/// This configuration settings is used to optimized the communication performance with the
-/// debugger and depends on the USB peripheral. Change setting to 1024 for High-Speed USB.
-#define DAP_PACKET_SIZE         64              ///< USB: 64 = Full-Speed, 1024 = High-Speed.
+/// This configuration settings is used to optimize the communication performance with the
+/// debugger and depends on the USB peripheral. Typical vales are 64 for Full-speed USB HID or WinUSB,
+/// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
+#define DAP_PACKET_SIZE         64U             ///< Specifies Packet Size in bytes.
 
 /// Maximum Package Buffers for Command and Response data.
-/// This configuration settings is used to optimized the communication performance with the
+/// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. For devices with limited RAM or USB buffer the
-/// setting can be reduced (valid range is 1 .. 255). Change setting to 4 for High-Speed USB.
-#define DAP_PACKET_COUNT        12              ///< Buffers: 64 = Full-Speed, 4 = High-Speed.
+/// setting can be reduced (valid range is 1 .. 255).
+#define DAP_PACKET_COUNT        12U            ///< Specifies number of packets buffered.
 
 #define DAP_PACKET_QUEUE_SIZE (DAP_PACKET_COUNT+8)
+
+/// Indicate that UART Serial Wire Output (SWO) trace is available.
+/// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
+#define SWO_UART                0               ///< SWO UART:  1 = available, 0 = not available.
+
+/// Maximum SWO UART Baudrate.
+#define SWO_UART_MAX_BAUDRATE   10000000U       ///< SWO UART Maximum Baudrate in Hz.
+
+/// Indicate that Manchester Serial Wire Output (SWO) trace is available.
+/// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
+#define SWO_MANCHESTER          0               ///< SWO Manchester:  1 = available, 0 = not available.
+
+/// SWO Trace Buffer Size.
+#define SWO_BUFFER_SIZE         4096U           ///< SWO Trace Buffer Size in bytes (must be 2^n).
+
+/// SWO Streaming Trace.
+#define SWO_STREAM              0               ///< SWO Streaming Trace: 1 = available, 0 = not available.
+
+/// Clock frequency of the Test Domain Timer. Timer value is returned with \ref TIMESTAMP_GET.
+#define TIMESTAMP_CLOCK         48000000U       ///< Timestamp clock in Hz (0 = timestamps not supported).
 
 /// Debug Unit is connected to fixed Target Device.
 /// The Debug Unit may be part of an evaluation board and always connected to a fixed
@@ -123,6 +129,33 @@ Provides definitions about:
 #define TARGET_DEVICE_VENDOR    ""              ///< String indicating the Silicon Vendor
 #define TARGET_DEVICE_NAME      ""              ///< String indicating the Target Device
 #endif
+
+/** Get Vendor ID string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetVendorString (char *str) {
+  (void)str;
+  return (0U);
+}
+
+/** Get Product ID string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetProductString (char *str) {
+  (void)str;
+  return (0U);
+}
+
+/** Get Serial Number string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetSerNumString (char *str) {
+  (void)str;
+  return (0U);
+}
 
 ///@}
 
@@ -142,4 +175,4 @@ Provides definitions about:
 
 #define SWDIO_GPIO_PIN_NUM      0
 
-#endif
+#endif /* __DAP_CONFIG_H__ */

--- a/src/stm32f042/dap42k6u/DAP/CMSIS_DAP_config.h
+++ b/src/stm32f042/dap42k6u/DAP/CMSIS_DAP_config.h
@@ -1,61 +1,46 @@
 /*
- * Copyright (c) 2015, Devan Lai
+ * Copyright (c) 2013-2017 ARM Limited. All rights reserved.
  *
- * Permission to use, copy, modify, and/or distribute this software
- * for any purpose with or without fee is hereby granted, provided
- * that the above copyright notice and this permission notice
- * appear in all copies.
+ * SPDX-License-Identifier: Apache-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
- * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
- * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
- * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
- * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- */
-
-/*
-    Portions of this file are derived from:
-
-    Dapper Mime - an open-source CMSIS-DAP implementation
-    HAL for STM32F0xx2
-    this file is used by the mbed CMSIS-DAP routines
-
-    Copyright (C) 2014 Peter Lawrence
-
-    Permission is hereby granted, free of charge, to any person obtaining a 
-    copy of this software and associated documentation files (the "Software"), 
-    to deal in the Software without restriction, including without limitation 
-    the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-    and/or sell copies of the Software, and to permit persons to whom the 
-    Software is furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in 
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-    DEALINGS IN THE SOFTWARE.
-*/
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        1. December 2017
+ * $Revision:    V2.0.0
+ *
+ * Project:      CMSIS-DAP Configuration
+ * Title:        DAP_config.h CMSIS-DAP Configuration File (Template)
+ *
+ *---------------------------------------------------------------------------*/
 
 #ifndef __DAP_CONFIG_H__
 #define __DAP_CONFIG_H__
+
 
 //**************************************************************************************************
 /**
 \defgroup DAP_Config_Debug_gr CMSIS-DAP Debug Unit Information
 \ingroup DAP_ConfigIO_gr
 @{
-Provides definitions about:
+Provides definitions about the hardware and configuration of the Debug Unit.
+
+This information includes:
  - Definition of Cortex-M processor parameters used in CMSIS-DAP Debug Unit.
+ - Debug Unit Identification strings (Vendor, Product, Serial Number).
  - Debug Unit communication packet size.
- - Debug Access Port communication mode (JTAG or SWD).
+ - Debug Access Port supported modes and settings (JTAG/SWD and SWO).
  - Optional information about a connected Target Device (for Evaluation Boards).
 */
 
@@ -65,19 +50,19 @@ Provides definitions about:
 
 /// Processor Clock of the Cortex-M MCU used in the Debug Unit.
 /// This value is used to calculate the SWD/JTAG clock speed.
-#define CPU_CLOCK               48000000        ///< Specifies the CPU Clock in Hz
+#define CPU_CLOCK               48000000U      ///< Specifies the CPU Clock in Hz.
 
 /// Number of processor cycles for I/O Port write operations.
 /// This value is used to calculate the SWD/JTAG clock speed that is generated with I/O
 /// Port write operations in the Debug Unit by a Cortex-M MCU. Most Cortex-M processors
-/// requrie 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
+/// require 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
 /// a Cortex-M0+ processor with high-speed peripheral I/O only 1 processor cycle might be
 /// required.
-#define IO_PORT_WRITE_CYCLES    2               ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0
+#define IO_PORT_WRITE_CYCLES    2U              ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0.
 
 /// Indicate that Serial Wire Debug (SWD) communication mode is available at the Debug Access Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
-#define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available
+#define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available.
 
 /// Indicate that JTAG communication mode is available at the Debug Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
@@ -89,29 +74,50 @@ Provides definitions about:
 
 /// Configure maximum number of JTAG devices on the scan chain connected to the Debug Access Port.
 /// This setting impacts the RAM requirements of the Debug Unit. Valid range is 1 .. 255.
-#define DAP_JTAG_DEV_CNT        8               ///< Maximum number of JTAG devices on scan chain
+#define DAP_JTAG_DEV_CNT        8U              ///< Maximum number of JTAG devices on scan chain
 
 /// Default communication mode on the Debug Access Port.
 /// Used for the command \ref DAP_Connect when Port Default mode is selected.
-#define DAP_DEFAULT_PORT        1               ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
+#define DAP_DEFAULT_PORT        1U              ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
 
 /// Default communication speed on the Debug Access Port for SWD and JTAG mode.
 /// Used to initialize the default SWD/JTAG clock frequency.
 /// The command \ref DAP_SWJ_Clock can be used to overwrite this default setting.
-#define DAP_DEFAULT_SWJ_CLOCK   10000000         ///< Default SWD/JTAG clock frequency in Hz.
+#define DAP_DEFAULT_SWJ_CLOCK   10000000U        ///< Default SWD/JTAG clock frequency in Hz.
 
 /// Maximum Package Size for Command and Response data.
-/// This configuration settings is used to optimized the communication performance with the
-/// debugger and depends on the USB peripheral. Change setting to 1024 for High-Speed USB.
-#define DAP_PACKET_SIZE         64              ///< USB: 64 = Full-Speed, 1024 = High-Speed.
+/// This configuration settings is used to optimize the communication performance with the
+/// debugger and depends on the USB peripheral. Typical vales are 64 for Full-speed USB HID or WinUSB,
+/// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
+#define DAP_PACKET_SIZE         64U             ///< Specifies Packet Size in bytes.
 
 /// Maximum Package Buffers for Command and Response data.
-/// This configuration settings is used to optimized the communication performance with the
+/// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. For devices with limited RAM or USB buffer the
-/// setting can be reduced (valid range is 1 .. 255). Change setting to 4 for High-Speed USB.
-#define DAP_PACKET_COUNT        12              ///< Buffers: 64 = Full-Speed, 4 = High-Speed.
+/// setting can be reduced (valid range is 1 .. 255).
+#define DAP_PACKET_COUNT        12U            ///< Specifies number of packets buffered.
 
 #define DAP_PACKET_QUEUE_SIZE (DAP_PACKET_COUNT+8)
+
+/// Indicate that UART Serial Wire Output (SWO) trace is available.
+/// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
+#define SWO_UART                0               ///< SWO UART:  1 = available, 0 = not available.
+
+/// Maximum SWO UART Baudrate.
+#define SWO_UART_MAX_BAUDRATE   10000000U       ///< SWO UART Maximum Baudrate in Hz.
+
+/// Indicate that Manchester Serial Wire Output (SWO) trace is available.
+/// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
+#define SWO_MANCHESTER          0               ///< SWO Manchester:  1 = available, 0 = not available.
+
+/// SWO Trace Buffer Size.
+#define SWO_BUFFER_SIZE         4096U           ///< SWO Trace Buffer Size in bytes (must be 2^n).
+
+/// SWO Streaming Trace.
+#define SWO_STREAM              0               ///< SWO Streaming Trace: 1 = available, 0 = not available.
+
+/// Clock frequency of the Test Domain Timer. Timer value is returned with \ref TIMESTAMP_GET.
+#define TIMESTAMP_CLOCK         48000000U       ///< Timestamp clock in Hz (0 = timestamps not supported).
 
 /// Debug Unit is connected to fixed Target Device.
 /// The Debug Unit may be part of an evaluation board and always connected to a fixed
@@ -123,6 +129,33 @@ Provides definitions about:
 #define TARGET_DEVICE_VENDOR    ""              ///< String indicating the Silicon Vendor
 #define TARGET_DEVICE_NAME      ""              ///< String indicating the Target Device
 #endif
+
+/** Get Vendor ID string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetVendorString (char *str) {
+  (void)str;
+  return (0U);
+}
+
+/** Get Product ID string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetProductString (char *str) {
+  (void)str;
+  return (0U);
+}
+
+/** Get Serial Number string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetSerNumString (char *str) {
+  (void)str;
+  return (0U);
+}
 
 ///@}
 
@@ -142,4 +175,4 @@ Provides definitions about:
 
 #define SWDIO_GPIO_PIN_NUM      3
 
-#endif
+#endif /* __DAP_CONFIG_H__ */

--- a/src/stm32f042/kitchen42/DAP/CMSIS_DAP_config.h
+++ b/src/stm32f042/kitchen42/DAP/CMSIS_DAP_config.h
@@ -1,61 +1,46 @@
 /*
- * Copyright (c) 2015, Devan Lai
+ * Copyright (c) 2013-2017 ARM Limited. All rights reserved.
  *
- * Permission to use, copy, modify, and/or distribute this software
- * for any purpose with or without fee is hereby granted, provided
- * that the above copyright notice and this permission notice
- * appear in all copies.
+ * SPDX-License-Identifier: Apache-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
- * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
- * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
- * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
- * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- */
-
-/*
-    Portions of this file are derived from:
-
-    Dapper Mime - an open-source CMSIS-DAP implementation
-    HAL for STM32F0xx2
-    this file is used by the mbed CMSIS-DAP routines
-
-    Copyright (C) 2014 Peter Lawrence
-
-    Permission is hereby granted, free of charge, to any person obtaining a 
-    copy of this software and associated documentation files (the "Software"), 
-    to deal in the Software without restriction, including without limitation 
-    the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-    and/or sell copies of the Software, and to permit persons to whom the 
-    Software is furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in 
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-    DEALINGS IN THE SOFTWARE.
-*/
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        1. December 2017
+ * $Revision:    V2.0.0
+ *
+ * Project:      CMSIS-DAP Configuration
+ * Title:        DAP_config.h CMSIS-DAP Configuration File (Template)
+ *
+ *---------------------------------------------------------------------------*/
 
 #ifndef __DAP_CONFIG_H__
 #define __DAP_CONFIG_H__
+
 
 //**************************************************************************************************
 /**
 \defgroup DAP_Config_Debug_gr CMSIS-DAP Debug Unit Information
 \ingroup DAP_ConfigIO_gr
 @{
-Provides definitions about:
+Provides definitions about the hardware and configuration of the Debug Unit.
+
+This information includes:
  - Definition of Cortex-M processor parameters used in CMSIS-DAP Debug Unit.
+ - Debug Unit Identification strings (Vendor, Product, Serial Number).
  - Debug Unit communication packet size.
- - Debug Access Port communication mode (JTAG or SWD).
+ - Debug Access Port supported modes and settings (JTAG/SWD and SWO).
  - Optional information about a connected Target Device (for Evaluation Boards).
 */
 
@@ -65,19 +50,19 @@ Provides definitions about:
 
 /// Processor Clock of the Cortex-M MCU used in the Debug Unit.
 /// This value is used to calculate the SWD/JTAG clock speed.
-#define CPU_CLOCK               48000000        ///< Specifies the CPU Clock in Hz
+#define CPU_CLOCK               48000000U      ///< Specifies the CPU Clock in Hz.
 
 /// Number of processor cycles for I/O Port write operations.
 /// This value is used to calculate the SWD/JTAG clock speed that is generated with I/O
 /// Port write operations in the Debug Unit by a Cortex-M MCU. Most Cortex-M processors
-/// requrie 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
+/// require 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
 /// a Cortex-M0+ processor with high-speed peripheral I/O only 1 processor cycle might be
 /// required.
-#define IO_PORT_WRITE_CYCLES    2               ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0
+#define IO_PORT_WRITE_CYCLES    2U              ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0.
 
 /// Indicate that Serial Wire Debug (SWD) communication mode is available at the Debug Access Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
-#define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available
+#define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available.
 
 /// Indicate that JTAG communication mode is available at the Debug Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
@@ -89,29 +74,50 @@ Provides definitions about:
 
 /// Configure maximum number of JTAG devices on the scan chain connected to the Debug Access Port.
 /// This setting impacts the RAM requirements of the Debug Unit. Valid range is 1 .. 255.
-#define DAP_JTAG_DEV_CNT        8               ///< Maximum number of JTAG devices on scan chain
+#define DAP_JTAG_DEV_CNT        8U              ///< Maximum number of JTAG devices on scan chain
 
 /// Default communication mode on the Debug Access Port.
 /// Used for the command \ref DAP_Connect when Port Default mode is selected.
-#define DAP_DEFAULT_PORT        1               ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
+#define DAP_DEFAULT_PORT        1U              ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
 
 /// Default communication speed on the Debug Access Port for SWD and JTAG mode.
 /// Used to initialize the default SWD/JTAG clock frequency.
 /// The command \ref DAP_SWJ_Clock can be used to overwrite this default setting.
-#define DAP_DEFAULT_SWJ_CLOCK   10000000         ///< Default SWD/JTAG clock frequency in Hz.
+#define DAP_DEFAULT_SWJ_CLOCK   10000000U        ///< Default SWD/JTAG clock frequency in Hz.
 
 /// Maximum Package Size for Command and Response data.
-/// This configuration settings is used to optimized the communication performance with the
-/// debugger and depends on the USB peripheral. Change setting to 1024 for High-Speed USB.
-#define DAP_PACKET_SIZE         64              ///< USB: 64 = Full-Speed, 1024 = High-Speed.
+/// This configuration settings is used to optimize the communication performance with the
+/// debugger and depends on the USB peripheral. Typical vales are 64 for Full-speed USB HID or WinUSB,
+/// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
+#define DAP_PACKET_SIZE         64U             ///< Specifies Packet Size in bytes.
 
 /// Maximum Package Buffers for Command and Response data.
-/// This configuration settings is used to optimized the communication performance with the
+/// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. For devices with limited RAM or USB buffer the
-/// setting can be reduced (valid range is 1 .. 255). Change setting to 4 for High-Speed USB.
-#define DAP_PACKET_COUNT        4              ///< Buffers: 64 = Full-Speed, 4 = High-Speed.
+/// setting can be reduced (valid range is 1 .. 255).
+#define DAP_PACKET_COUNT        4U             ///< Specifies number of packets buffered.
 
 #define DAP_PACKET_QUEUE_SIZE (DAP_PACKET_COUNT+4)
+
+/// Indicate that UART Serial Wire Output (SWO) trace is available.
+/// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
+#define SWO_UART                0               ///< SWO UART:  1 = available, 0 = not available.
+
+/// Maximum SWO UART Baudrate.
+#define SWO_UART_MAX_BAUDRATE   10000000U       ///< SWO UART Maximum Baudrate in Hz.
+
+/// Indicate that Manchester Serial Wire Output (SWO) trace is available.
+/// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
+#define SWO_MANCHESTER          0               ///< SWO Manchester:  1 = available, 0 = not available.
+
+/// SWO Trace Buffer Size.
+#define SWO_BUFFER_SIZE         4096U           ///< SWO Trace Buffer Size in bytes (must be 2^n).
+
+/// SWO Streaming Trace.
+#define SWO_STREAM              0               ///< SWO Streaming Trace: 1 = available, 0 = not available.
+
+/// Clock frequency of the Test Domain Timer. Timer value is returned with \ref TIMESTAMP_GET.
+#define TIMESTAMP_CLOCK         48000000U       ///< Timestamp clock in Hz (0 = timestamps not supported).
 
 /// Debug Unit is connected to fixed Target Device.
 /// The Debug Unit may be part of an evaluation board and always connected to a fixed
@@ -123,6 +129,33 @@ Provides definitions about:
 #define TARGET_DEVICE_VENDOR    ""              ///< String indicating the Silicon Vendor
 #define TARGET_DEVICE_NAME      ""              ///< String indicating the Target Device
 #endif
+
+/** Get Vendor ID string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetVendorString (char *str) {
+  (void)str;
+  return (0U);
+}
+
+/** Get Product ID string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetProductString (char *str) {
+  (void)str;
+  return (0U);
+}
+
+/** Get Serial Number string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetSerNumString (char *str) {
+  (void)str;
+  return (0U);
+}
 
 ///@}
 
@@ -142,4 +175,4 @@ Provides definitions about:
 
 #define SWDIO_GPIO_PIN_NUM      15
 
-#endif
+#endif /* __DAP_CONFIG_H__ */

--- a/src/stm32f103/DAP/CMSIS_DAP_hal.h
+++ b/src/stm32f103/DAP/CMSIS_DAP_hal.h
@@ -49,6 +49,23 @@
 
 #include <libopencm3/stm32/gpio.h>
 #include "DAP/CMSIS_DAP_config.h"
+#include "tick.h"
+#include <libopencm3/cm3/systick.h>
+#include <libopencmsis/core_cm3.h>
+
+
+/*
+ * TIMESTAMP SUPPORT
+ */
+
+// Get current timestamp value, in micro-seconds:
+// Use SYSTICK value and timer ticks, assume 1ms counter.
+static __inline uint32_t TIMESTAMP_GET (void) {
+  uint32_t reload = STK_RVR;
+  uint32_t current = STK_CVR;
+  uint32_t tick = get_ticks();
+  return tick * 1000U + (reload - current) / (CPU_CLOCK / TIMESTAMP_CLOCK);
+}
 
 /*
 SWD functionality

--- a/src/stm32f103/bluepill/DAP/CMSIS_DAP_config.h
+++ b/src/stm32f103/bluepill/DAP/CMSIS_DAP_config.h
@@ -1,61 +1,46 @@
 /*
- * Copyright (c) 2016, Devan Lai
+ * Copyright (c) 2013-2017 ARM Limited. All rights reserved.
  *
- * Permission to use, copy, modify, and/or distribute this software
- * for any purpose with or without fee is hereby granted, provided
- * that the above copyright notice and this permission notice
- * appear in all copies.
+ * SPDX-License-Identifier: Apache-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
- * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
- * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
- * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
- * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- */
-
-/*
-    Portions of this file are derived from:
-
-    Dapper Mime - an open-source CMSIS-DAP implementation
-    HAL for STM32F0xx2
-    this file is used by the mbed CMSIS-DAP routines
-
-    Copyright (C) 2014 Peter Lawrence
-
-    Permission is hereby granted, free of charge, to any person obtaining a 
-    copy of this software and associated documentation files (the "Software"), 
-    to deal in the Software without restriction, including without limitation 
-    the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-    and/or sell copies of the Software, and to permit persons to whom the 
-    Software is furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in 
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-    DEALINGS IN THE SOFTWARE.
-*/
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        1. December 2017
+ * $Revision:    V2.0.0
+ *
+ * Project:      CMSIS-DAP Configuration
+ * Title:        DAP_config.h CMSIS-DAP Configuration File (Template)
+ *
+ *---------------------------------------------------------------------------*/
 
 #ifndef __DAP_CONFIG_H__
 #define __DAP_CONFIG_H__
+
 
 //**************************************************************************************************
 /**
 \defgroup DAP_Config_Debug_gr CMSIS-DAP Debug Unit Information
 \ingroup DAP_ConfigIO_gr
 @{
-Provides definitions about:
+Provides definitions about the hardware and configuration of the Debug Unit.
+
+This information includes:
  - Definition of Cortex-M processor parameters used in CMSIS-DAP Debug Unit.
+ - Debug Unit Identification strings (Vendor, Product, Serial Number).
  - Debug Unit communication packet size.
- - Debug Access Port communication mode (JTAG or SWD).
+ - Debug Access Port supported modes and settings (JTAG/SWD and SWO).
  - Optional information about a connected Target Device (for Evaluation Boards).
 */
 
@@ -65,19 +50,19 @@ Provides definitions about:
 
 /// Processor Clock of the Cortex-M MCU used in the Debug Unit.
 /// This value is used to calculate the SWD/JTAG clock speed.
-#define CPU_CLOCK               72000000        ///< Specifies the CPU Clock in Hz
+#define CPU_CLOCK               72000000U      ///< Specifies the CPU Clock in Hz.
 
 /// Number of processor cycles for I/O Port write operations.
 /// This value is used to calculate the SWD/JTAG clock speed that is generated with I/O
 /// Port write operations in the Debug Unit by a Cortex-M MCU. Most Cortex-M processors
-/// requrie 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
+/// require 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
 /// a Cortex-M0+ processor with high-speed peripheral I/O only 1 processor cycle might be
 /// required.
-#define IO_PORT_WRITE_CYCLES    2               ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0
+#define IO_PORT_WRITE_CYCLES    2U              ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0.
 
 /// Indicate that Serial Wire Debug (SWD) communication mode is available at the Debug Access Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
-#define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available
+#define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available.
 
 /// Indicate that JTAG communication mode is available at the Debug Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
@@ -89,29 +74,50 @@ Provides definitions about:
 
 /// Configure maximum number of JTAG devices on the scan chain connected to the Debug Access Port.
 /// This setting impacts the RAM requirements of the Debug Unit. Valid range is 1 .. 255.
-#define DAP_JTAG_DEV_CNT        8               ///< Maximum number of JTAG devices on scan chain
+#define DAP_JTAG_DEV_CNT        8U              ///< Maximum number of JTAG devices on scan chain
 
 /// Default communication mode on the Debug Access Port.
 /// Used for the command \ref DAP_Connect when Port Default mode is selected.
-#define DAP_DEFAULT_PORT        1               ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
+#define DAP_DEFAULT_PORT        1U              ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
 
 /// Default communication speed on the Debug Access Port for SWD and JTAG mode.
 /// Used to initialize the default SWD/JTAG clock frequency.
 /// The command \ref DAP_SWJ_Clock can be used to overwrite this default setting.
-#define DAP_DEFAULT_SWJ_CLOCK   10000000         ///< Default SWD/JTAG clock frequency in Hz.
+#define DAP_DEFAULT_SWJ_CLOCK   10000000U        ///< Default SWD/JTAG clock frequency in Hz.
 
 /// Maximum Package Size for Command and Response data.
-/// This configuration settings is used to optimized the communication performance with the
-/// debugger and depends on the USB peripheral. Change setting to 1024 for High-Speed USB.
-#define DAP_PACKET_SIZE         64              ///< USB: 64 = Full-Speed, 1024 = High-Speed.
+/// This configuration settings is used to optimize the communication performance with the
+/// debugger and depends on the USB peripheral. Typical vales are 64 for Full-speed USB HID or WinUSB,
+/// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
+#define DAP_PACKET_SIZE         64U             ///< Specifies Packet Size in bytes.
 
 /// Maximum Package Buffers for Command and Response data.
-/// This configuration settings is used to optimized the communication performance with the
+/// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. For devices with limited RAM or USB buffer the
-/// setting can be reduced (valid range is 1 .. 255). Change setting to 4 for High-Speed USB.
-#define DAP_PACKET_COUNT        12              ///< Buffers: 64 = Full-Speed, 4 = High-Speed.
+/// setting can be reduced (valid range is 1 .. 255).
+#define DAP_PACKET_COUNT        12U            ///< Specifies number of packets buffered.
 
 #define DAP_PACKET_QUEUE_SIZE (DAP_PACKET_COUNT+8)
+
+/// Indicate that UART Serial Wire Output (SWO) trace is available.
+/// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
+#define SWO_UART                0               ///< SWO UART:  1 = available, 0 = not available.
+
+/// Maximum SWO UART Baudrate.
+#define SWO_UART_MAX_BAUDRATE   10000000U       ///< SWO UART Maximum Baudrate in Hz.
+
+/// Indicate that Manchester Serial Wire Output (SWO) trace is available.
+/// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
+#define SWO_MANCHESTER          0               ///< SWO Manchester:  1 = available, 0 = not available.
+
+/// SWO Trace Buffer Size.
+#define SWO_BUFFER_SIZE         4096U           ///< SWO Trace Buffer Size in bytes (must be 2^n).
+
+/// SWO Streaming Trace.
+#define SWO_STREAM              0               ///< SWO Streaming Trace: 1 = available, 0 = not available.
+
+/// Clock frequency of the Test Domain Timer. Timer value is returned with \ref TIMESTAMP_GET.
+#define TIMESTAMP_CLOCK         72000000U       ///< Timestamp clock in Hz (0 = timestamps not supported).
 
 /// Debug Unit is connected to fixed Target Device.
 /// The Debug Unit may be part of an evaluation board and always connected to a fixed
@@ -123,6 +129,33 @@ Provides definitions about:
 #define TARGET_DEVICE_VENDOR    ""              ///< String indicating the Silicon Vendor
 #define TARGET_DEVICE_NAME      ""              ///< String indicating the Target Device
 #endif
+
+/** Get Vendor ID string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetVendorString (char *str) {
+  (void)str;
+  return (0U);
+}
+
+/** Get Product ID string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetProductString (char *str) {
+  (void)str;
+  return (0U);
+}
+
+/** Get Serial Number string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetSerNumString (char *str) {
+  (void)str;
+  return (0U);
+}
 
 ///@}
 
@@ -142,4 +175,4 @@ Provides definitions about:
 
 #define SWDIO_GPIO_PIN_NUM      14
 
-#endif
+#endif /* __DAP_CONFIG_H__ */

--- a/src/stm32f103/stlinkv2-1/DAP/CMSIS_DAP_config.h
+++ b/src/stm32f103/stlinkv2-1/DAP/CMSIS_DAP_config.h
@@ -1,61 +1,46 @@
 /*
- * Copyright (c) 2016, Devan Lai
+ * Copyright (c) 2013-2017 ARM Limited. All rights reserved.
  *
- * Permission to use, copy, modify, and/or distribute this software
- * for any purpose with or without fee is hereby granted, provided
- * that the above copyright notice and this permission notice
- * appear in all copies.
+ * SPDX-License-Identifier: Apache-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
- * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
- * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
- * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
- * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- */
-
-/*
-    Portions of this file are derived from:
-
-    Dapper Mime - an open-source CMSIS-DAP implementation
-    HAL for STM32F0xx2
-    this file is used by the mbed CMSIS-DAP routines
-
-    Copyright (C) 2014 Peter Lawrence
-
-    Permission is hereby granted, free of charge, to any person obtaining a 
-    copy of this software and associated documentation files (the "Software"), 
-    to deal in the Software without restriction, including without limitation 
-    the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-    and/or sell copies of the Software, and to permit persons to whom the 
-    Software is furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in 
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-    DEALINGS IN THE SOFTWARE.
-*/
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        1. December 2017
+ * $Revision:    V2.0.0
+ *
+ * Project:      CMSIS-DAP Configuration
+ * Title:        DAP_config.h CMSIS-DAP Configuration File (Template)
+ *
+ *---------------------------------------------------------------------------*/
 
 #ifndef __DAP_CONFIG_H__
 #define __DAP_CONFIG_H__
+
 
 //**************************************************************************************************
 /**
 \defgroup DAP_Config_Debug_gr CMSIS-DAP Debug Unit Information
 \ingroup DAP_ConfigIO_gr
 @{
-Provides definitions about:
+Provides definitions about the hardware and configuration of the Debug Unit.
+
+This information includes:
  - Definition of Cortex-M processor parameters used in CMSIS-DAP Debug Unit.
+ - Debug Unit Identification strings (Vendor, Product, Serial Number).
  - Debug Unit communication packet size.
- - Debug Access Port communication mode (JTAG or SWD).
+ - Debug Access Port supported modes and settings (JTAG/SWD and SWO).
  - Optional information about a connected Target Device (for Evaluation Boards).
 */
 
@@ -65,19 +50,19 @@ Provides definitions about:
 
 /// Processor Clock of the Cortex-M MCU used in the Debug Unit.
 /// This value is used to calculate the SWD/JTAG clock speed.
-#define CPU_CLOCK               72000000        ///< Specifies the CPU Clock in Hz
+#define CPU_CLOCK               72000000U      ///< Specifies the CPU Clock in Hz.
 
 /// Number of processor cycles for I/O Port write operations.
 /// This value is used to calculate the SWD/JTAG clock speed that is generated with I/O
 /// Port write operations in the Debug Unit by a Cortex-M MCU. Most Cortex-M processors
-/// requrie 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
+/// require 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
 /// a Cortex-M0+ processor with high-speed peripheral I/O only 1 processor cycle might be
 /// required.
-#define IO_PORT_WRITE_CYCLES    2               ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0
+#define IO_PORT_WRITE_CYCLES    2U              ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0.
 
 /// Indicate that Serial Wire Debug (SWD) communication mode is available at the Debug Access Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
-#define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available
+#define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available.
 
 /// Indicate that JTAG communication mode is available at the Debug Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
@@ -89,29 +74,50 @@ Provides definitions about:
 
 /// Configure maximum number of JTAG devices on the scan chain connected to the Debug Access Port.
 /// This setting impacts the RAM requirements of the Debug Unit. Valid range is 1 .. 255.
-#define DAP_JTAG_DEV_CNT        8               ///< Maximum number of JTAG devices on scan chain
+#define DAP_JTAG_DEV_CNT        8U              ///< Maximum number of JTAG devices on scan chain
 
 /// Default communication mode on the Debug Access Port.
 /// Used for the command \ref DAP_Connect when Port Default mode is selected.
-#define DAP_DEFAULT_PORT        1               ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
+#define DAP_DEFAULT_PORT        1U              ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
 
 /// Default communication speed on the Debug Access Port for SWD and JTAG mode.
 /// Used to initialize the default SWD/JTAG clock frequency.
 /// The command \ref DAP_SWJ_Clock can be used to overwrite this default setting.
-#define DAP_DEFAULT_SWJ_CLOCK   10000000         ///< Default SWD/JTAG clock frequency in Hz.
+#define DAP_DEFAULT_SWJ_CLOCK   10000000U        ///< Default SWD/JTAG clock frequency in Hz.
 
 /// Maximum Package Size for Command and Response data.
-/// This configuration settings is used to optimized the communication performance with the
-/// debugger and depends on the USB peripheral. Change setting to 1024 for High-Speed USB.
-#define DAP_PACKET_SIZE         64              ///< USB: 64 = Full-Speed, 1024 = High-Speed.
+/// This configuration settings is used to optimize the communication performance with the
+/// debugger and depends on the USB peripheral. Typical vales are 64 for Full-speed USB HID or WinUSB,
+/// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
+#define DAP_PACKET_SIZE         64U             ///< Specifies Packet Size in bytes.
 
 /// Maximum Package Buffers for Command and Response data.
-/// This configuration settings is used to optimized the communication performance with the
+/// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. For devices with limited RAM or USB buffer the
-/// setting can be reduced (valid range is 1 .. 255). Change setting to 4 for High-Speed USB.
-#define DAP_PACKET_COUNT        12              ///< Buffers: 64 = Full-Speed, 4 = High-Speed.
+/// setting can be reduced (valid range is 1 .. 255).
+#define DAP_PACKET_COUNT        12U            ///< Specifies number of packets buffered.
 
 #define DAP_PACKET_QUEUE_SIZE (DAP_PACKET_COUNT+8)
+
+/// Indicate that UART Serial Wire Output (SWO) trace is available.
+/// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
+#define SWO_UART                0               ///< SWO UART:  1 = available, 0 = not available.
+
+/// Maximum SWO UART Baudrate.
+#define SWO_UART_MAX_BAUDRATE   10000000U       ///< SWO UART Maximum Baudrate in Hz.
+
+/// Indicate that Manchester Serial Wire Output (SWO) trace is available.
+/// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
+#define SWO_MANCHESTER          0               ///< SWO Manchester:  1 = available, 0 = not available.
+
+/// SWO Trace Buffer Size.
+#define SWO_BUFFER_SIZE         4096U           ///< SWO Trace Buffer Size in bytes (must be 2^n).
+
+/// SWO Streaming Trace.
+#define SWO_STREAM              0               ///< SWO Streaming Trace: 1 = available, 0 = not available.
+
+/// Clock frequency of the Test Domain Timer. Timer value is returned with \ref TIMESTAMP_GET.
+#define TIMESTAMP_CLOCK         72000000U       ///< Timestamp clock in Hz (0 = timestamps not supported).
 
 /// Debug Unit is connected to fixed Target Device.
 /// The Debug Unit may be part of an evaluation board and always connected to a fixed
@@ -123,6 +129,33 @@ Provides definitions about:
 #define TARGET_DEVICE_VENDOR    ""              ///< String indicating the Silicon Vendor
 #define TARGET_DEVICE_NAME      ""              ///< String indicating the Target Device
 #endif
+
+/** Get Vendor ID string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetVendorString (char *str) {
+  (void)str;
+  return (0U);
+}
+
+/** Get Product ID string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetProductString (char *str) {
+  (void)str;
+  return (0U);
+}
+
+/** Get Serial Number string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetSerNumString (char *str) {
+  (void)str;
+  return (0U);
+}
 
 ///@}
 
@@ -142,4 +175,4 @@ Provides definitions about:
 
 #define SWDIO_GPIO_PIN_NUM      14
 
-#endif
+#endif /* __DAP_CONFIG_H__ */

--- a/src/stm32f103/stlinkv2-dongle/DAP/CMSIS_DAP_config.h
+++ b/src/stm32f103/stlinkv2-dongle/DAP/CMSIS_DAP_config.h
@@ -1,61 +1,46 @@
 /*
- * Copyright (c) 2016, Devan Lai
+ * Copyright (c) 2013-2017 ARM Limited. All rights reserved.
  *
- * Permission to use, copy, modify, and/or distribute this software
- * for any purpose with or without fee is hereby granted, provided
- * that the above copyright notice and this permission notice
- * appear in all copies.
+ * SPDX-License-Identifier: Apache-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
- * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
- * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
- * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
- * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- */
-
-/*
-    Portions of this file are derived from:
-
-    Dapper Mime - an open-source CMSIS-DAP implementation
-    HAL for STM32F0xx2
-    this file is used by the mbed CMSIS-DAP routines
-
-    Copyright (C) 2014 Peter Lawrence
-
-    Permission is hereby granted, free of charge, to any person obtaining a 
-    copy of this software and associated documentation files (the "Software"), 
-    to deal in the Software without restriction, including without limitation 
-    the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-    and/or sell copies of the Software, and to permit persons to whom the 
-    Software is furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in 
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
-    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
-    DEALINGS IN THE SOFTWARE.
-*/
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        1. December 2017
+ * $Revision:    V2.0.0
+ *
+ * Project:      CMSIS-DAP Configuration
+ * Title:        DAP_config.h CMSIS-DAP Configuration File (Template)
+ *
+ *---------------------------------------------------------------------------*/
 
 #ifndef __DAP_CONFIG_H__
 #define __DAP_CONFIG_H__
+
 
 //**************************************************************************************************
 /**
 \defgroup DAP_Config_Debug_gr CMSIS-DAP Debug Unit Information
 \ingroup DAP_ConfigIO_gr
 @{
-Provides definitions about:
+Provides definitions about the hardware and configuration of the Debug Unit.
+
+This information includes:
  - Definition of Cortex-M processor parameters used in CMSIS-DAP Debug Unit.
+ - Debug Unit Identification strings (Vendor, Product, Serial Number).
  - Debug Unit communication packet size.
- - Debug Access Port communication mode (JTAG or SWD).
+ - Debug Access Port supported modes and settings (JTAG/SWD and SWO).
  - Optional information about a connected Target Device (for Evaluation Boards).
 */
 
@@ -65,19 +50,19 @@ Provides definitions about:
 
 /// Processor Clock of the Cortex-M MCU used in the Debug Unit.
 /// This value is used to calculate the SWD/JTAG clock speed.
-#define CPU_CLOCK               72000000        ///< Specifies the CPU Clock in Hz
+#define CPU_CLOCK               72000000U      ///< Specifies the CPU Clock in Hz.
 
 /// Number of processor cycles for I/O Port write operations.
 /// This value is used to calculate the SWD/JTAG clock speed that is generated with I/O
 /// Port write operations in the Debug Unit by a Cortex-M MCU. Most Cortex-M processors
-/// requrie 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
+/// require 2 processor cycles for a I/O Port Write operation.  If the Debug Unit uses
 /// a Cortex-M0+ processor with high-speed peripheral I/O only 1 processor cycle might be
 /// required.
-#define IO_PORT_WRITE_CYCLES    2               ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0
+#define IO_PORT_WRITE_CYCLES    2U              ///< I/O Cycles: 2=default, 1=Cortex-M0+ fast I/0.
 
 /// Indicate that Serial Wire Debug (SWD) communication mode is available at the Debug Access Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
-#define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available
+#define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available.
 
 /// Indicate that JTAG communication mode is available at the Debug Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
@@ -89,29 +74,50 @@ Provides definitions about:
 
 /// Configure maximum number of JTAG devices on the scan chain connected to the Debug Access Port.
 /// This setting impacts the RAM requirements of the Debug Unit. Valid range is 1 .. 255.
-#define DAP_JTAG_DEV_CNT        8               ///< Maximum number of JTAG devices on scan chain
+#define DAP_JTAG_DEV_CNT        8U              ///< Maximum number of JTAG devices on scan chain
 
 /// Default communication mode on the Debug Access Port.
 /// Used for the command \ref DAP_Connect when Port Default mode is selected.
-#define DAP_DEFAULT_PORT        1               ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
+#define DAP_DEFAULT_PORT        1U              ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
 
 /// Default communication speed on the Debug Access Port for SWD and JTAG mode.
 /// Used to initialize the default SWD/JTAG clock frequency.
 /// The command \ref DAP_SWJ_Clock can be used to overwrite this default setting.
-#define DAP_DEFAULT_SWJ_CLOCK   10000000         ///< Default SWD/JTAG clock frequency in Hz.
+#define DAP_DEFAULT_SWJ_CLOCK   10000000U        ///< Default SWD/JTAG clock frequency in Hz.
 
 /// Maximum Package Size for Command and Response data.
-/// This configuration settings is used to optimized the communication performance with the
-/// debugger and depends on the USB peripheral. Change setting to 1024 for High-Speed USB.
-#define DAP_PACKET_SIZE         64              ///< USB: 64 = Full-Speed, 1024 = High-Speed.
+/// This configuration settings is used to optimize the communication performance with the
+/// debugger and depends on the USB peripheral. Typical vales are 64 for Full-speed USB HID or WinUSB,
+/// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
+#define DAP_PACKET_SIZE         64U             ///< Specifies Packet Size in bytes.
 
 /// Maximum Package Buffers for Command and Response data.
-/// This configuration settings is used to optimized the communication performance with the
+/// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. For devices with limited RAM or USB buffer the
-/// setting can be reduced (valid range is 1 .. 255). Change setting to 4 for High-Speed USB.
-#define DAP_PACKET_COUNT        12              ///< Buffers: 64 = Full-Speed, 4 = High-Speed.
+/// setting can be reduced (valid range is 1 .. 255).
+#define DAP_PACKET_COUNT        12U            ///< Specifies number of packets buffered.
 
 #define DAP_PACKET_QUEUE_SIZE (DAP_PACKET_COUNT+8)
+
+/// Indicate that UART Serial Wire Output (SWO) trace is available.
+/// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
+#define SWO_UART                0               ///< SWO UART:  1 = available, 0 = not available.
+
+/// Maximum SWO UART Baudrate.
+#define SWO_UART_MAX_BAUDRATE   10000000U       ///< SWO UART Maximum Baudrate in Hz.
+
+/// Indicate that Manchester Serial Wire Output (SWO) trace is available.
+/// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
+#define SWO_MANCHESTER          0               ///< SWO Manchester:  1 = available, 0 = not available.
+
+/// SWO Trace Buffer Size.
+#define SWO_BUFFER_SIZE         4096U           ///< SWO Trace Buffer Size in bytes (must be 2^n).
+
+/// SWO Streaming Trace.
+#define SWO_STREAM              0               ///< SWO Streaming Trace: 1 = available, 0 = not available.
+
+/// Clock frequency of the Test Domain Timer. Timer value is returned with \ref TIMESTAMP_GET.
+#define TIMESTAMP_CLOCK         72000000U       ///< Timestamp clock in Hz (0 = timestamps not supported).
 
 /// Debug Unit is connected to fixed Target Device.
 /// The Debug Unit may be part of an evaluation board and always connected to a fixed
@@ -123,6 +129,33 @@ Provides definitions about:
 #define TARGET_DEVICE_VENDOR    ""              ///< String indicating the Silicon Vendor
 #define TARGET_DEVICE_NAME      ""              ///< String indicating the Target Device
 #endif
+
+/** Get Vendor ID string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetVendorString (char *str) {
+  (void)str;
+  return (0U);
+}
+
+/** Get Product ID string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetProductString (char *str) {
+  (void)str;
+  return (0U);
+}
+
+/** Get Serial Number string.
+\param str Pointer to buffer to store the string.
+\return String length.
+*/
+static inline uint8_t DAP_GetSerNumString (char *str) {
+  (void)str;
+  return (0U);
+}
 
 ///@}
 
@@ -142,4 +175,4 @@ Provides definitions about:
 
 #define SWDIO_GPIO_PIN_NUM      14
 
-#endif
+#endif /* __DAP_CONFIG_H__ */


### PR DESCRIPTION
This pull request updates CMSIS-DAP to version 2.0.

Only two changes to the original code:

- New DAP version uses TIMESTAMP_GET instead of TIMER, the TIMESTAMP is  implemented using the already running SYSTICK timer.

- To support new "ExecuteCommands" command, we call DAP_ExecuteCommand   instead of DAP_ProcessCommnad from application code.

With this version, openocd can debug multi-drop targets via SWD, like the RP2040 microcontroller.

Tested on a STLINK-V2 clone, debugging an RP2040 and an STM32F103.

This closes issue #16 
