### PR TITLE
Update the obsolete version of libopencm3.

### DIFF
--- a/src/stm32f103/bluepill/target.c
+++ b/src/stm32f103/bluepill/target.c
@@ -29,7 +29,8 @@ void cpu_setup(void) {
 
 /* Set STM32 to 72 MHz. */
 void clock_setup(void) {
-    rcc_clock_setup_in_hse_8mhz_out_72mhz();
+    // rcc_clock_setup_in_hse_8mhz_out_72mhz();
+    rcc_clock_setup_pll(&rcc_hse_configs[RCC_CLOCK_HSE8_72MHZ]);
 }
 
 void gpio_setup(void) {

--- a/src/stm32f103/stlinkv2-1/target.c
+++ b/src/stm32f103/stlinkv2-1/target.c
@@ -38,7 +38,8 @@ void cpu_setup(void) {
 
 /* Set STM32 to 72 MHz. */
 void clock_setup(void) {
-    rcc_clock_setup_in_hse_8mhz_out_72mhz();
+    // rcc_clock_setup_in_hse_8mhz_out_72mhz();
+    rcc_clock_setup_pll(&rcc_hse_configs[RCC_CLOCK_HSE8_72MHZ]);
 }
 
 void gpio_setup(void) {

--- a/src/stm32f103/stlinkv2-dongle/target.c
+++ b/src/stm32f103/stlinkv2-dongle/target.c
@@ -29,12 +29,13 @@ void cpu_setup(void) {
 
 /* Set STM32 to 72 MHz. */
 void clock_setup(void) {
-    rcc_clock_setup_in_hse_8mhz_out_72mhz();
+    // rcc_clock_setup_in_hse_8mhz_out_72mhz();
+    rcc_clock_setup_pll(&rcc_hse_configs[RCC_CLOCK_HSE8_72MHZ]);
 }
 
 void gpio_setup(void) {
     /*
-      LED0, 1, 2 on PA9, 
+      LED0, 1, 2 on PA9,
       RX (MCU-side) on PB11
       TGT_RST on PB6
       TGT_SWDIO, TGT_SWCLK on PB14, PB13

--- a/util/install-toolchain.sh
+++ b/util/install-toolchain.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
-URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2016q4/gcc-arm-none-eabi-6_2-2016q4-20161216-linux.tar.bz2
-TOOLCHAIN=gcc-arm-none-eabi-6_2-2016q4
+URL=https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi.tar.xz
+TOOLCHAIN=arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi
 TOOLCHAINS=$HOME/toolchains
 TOOLCHAIN_MISSING=0
 GCC=${TOOLCHAINS}/gcc-arm-embedded/bin/arm-none-eabi-gcc
@@ -15,7 +15,7 @@ fi;
 if [ $TOOLCHAIN_MISSING -eq 1 ]; then
     echo "Installing $TOOLCHAIN from $URL to ${TOOLCHAINS}"
     mkdir -p ${TOOLCHAINS}
-    wget -qO- $URL | tar xj -C ${TOOLCHAINS}
+    wget -qO- $URL | tar xJ -C ${TOOLCHAINS}
     rm -rf ${TOOLCHAINS}/gcc-arm-embedded
     ln -s $TOOLCHAIN ${TOOLCHAINS}/gcc-arm-embedded
 fi;


### PR DESCRIPTION
When compiling with the older versions of libopencm3, the following error occurs:

```
  GENHDR  include/libopencm3/stm32/f0/irq.json
  BUILD   lib/stm32/f0
/bin/sh: -c: line 2: unexpected EOF while looking for matching `"'
/bin/sh: -c: line 3: syntax error: unexpected end of file
make[1]: *** [Makefile:69: lib/stm32/f0] Error 2
make: *** [rules.mk:162: ../libopencm3/lib/libopencm3_stm32f0.a] Error 2
```

Compile successfully after updating to new version.