### PR TITLE
Update ARM toolchain to version 13.3.rel1

### DIFF
--- a/src/rules.mk
+++ b/src/rules.mk
@@ -129,7 +129,7 @@ endif
 # Used libraries
 
 LDLIBS     += -l$(LIBNAME)
-LDLIBS     += -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group
+LDLIBS     += -Wl,--start-group -lc -lgcc -Wl,--end-group
 
 ####################################################################
 ####################################################################

--- a/util/install-toolchain.sh
+++ b/util/install-toolchain.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
-URL=https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi.tar.xz
-TOOLCHAIN=arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi
+URL=https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi.tar.xz
+TOOLCHAIN=arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi
 TOOLCHAINS=$HOME/toolchains
 TOOLCHAIN_MISSING=0
 GCC=${TOOLCHAINS}/gcc-arm-embedded/bin/arm-none-eabi-gcc


### PR DESCRIPTION
Interesting: The new toolchain implements better optimizations. Size diff of the binaries:

| File name | Size diff in bytes |
|---|---|
| BRAINv3.3.bin | -120 |
| DAP103-BLUEPILL-DFU.bin | -64 |
| DAP103-BLUEPILL.bin | -60 |
| DAP103-DFU.bin | -68 |
| DAP103-NUCLEO-STBOOT.bin | -64 |
| DAP103.bin | -64 |
| DAP42.bin | -100 |
| DAP42DC.bin | -100 |
| DAP42K6U.bin | -96 |
| KITCHEN42.bin | -112 |
