### PR TITLE
Fix race condition with bulk packets

### DIFF
--- a/src/stm32f042/DAP/CMSIS_DAP_hal.h
+++ b/src/stm32f042/DAP/CMSIS_DAP_hal.h
@@ -248,6 +248,8 @@ static __inline void LED_CONNECTED_OUT (uint32_t bit) {
     } else {
         gpio_clear(LED_CON_GPIO_PORT, LED_CON_GPIO_PIN);
     }
+#else
+    (void)bit;
 #endif
 }
 
@@ -258,6 +260,8 @@ static __inline void LED_RUNNING_OUT (uint32_t bit) {
     } else {
         gpio_clear(LED_RUN_GPIO_PORT, LED_RUN_GPIO_PIN);
     }
+#else
+    (void)bit;
 #endif
 }
 
@@ -268,6 +272,8 @@ static __inline void LED_ACTIVITY_OUT (uint32_t bit) {
     } else {
         gpio_clear(LED_ACT_GPIO_PORT, LED_ACT_GPIO_PIN);
     }
+#else
+    (void)bit;
 #endif
 }
 


### PR DESCRIPTION
When receiving bulk data, a race occurs if a packet comes in as we're processing a new response packet. This results in an incorrect response getting sent to the host.

With openocd, this often manifests as:

```
Error: CMSIS-DAP command mismatch. Expected 0x6 received 0x5
Error: USB write: late transfer competed
Info : SWD DPIDR 0x4c013477
```

To work around this, disable interrupts when processing bulk (and hid) packets.